### PR TITLE
Enable parallel builds and expose the provision/rebuild timeout for user

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,27 +79,29 @@ See [Join load balancers](https://github.com/audiolize/vagrant-softlayer/wiki/Jo
 
 ### Instance Configuration
 
-Parameter          | Description                                                | Default         | Required
------------------- | -----------------------------------------------------------| ----------------| --------
-`datacenter`       | Datacenter shortname                                       | First available | no
-`dedicated`        | Allocate a dedicated CCI (non-shared host)                 | false           | no
-`disk_capacity`    | The capacity of each disk                                  |                 | no **
-`domain`           | The domain of the instance                                 |                 | yes
-`force_private_ip` | Use private IP for communication even if public IP is set  | false           | no
-`hostname`         | The hostname of the instance                               |                 | yes *
-`hourly_billing`   | Hourly billing type (false for monthly)                    | true            | no
-`image_guid`       | The global identifier for the compute or flex image to use |                 | no **
-`local_disk`       | Use a local disk (false for SAN)                           | true            | no
-`max_memory`       | The amount of RAM of the instance in Mb                    | 1024            | no
-`network_speed`    | Network port speed in Mbps                                 | 10              | no
-`operating_system` | The instance operating system identifier                   | UBUNTU_LATEST   | no **
-`post_install`     | URI of Post-install script to download                     |                 | no
-`private_only`     | Only create access to the private network                  | false           | no
-`ssh_key`          | ID or label of the SSH key(s) to provision                 |                 | yes
-`start_cpus`       | The number of processors of the instance                   | 1               | no
-`user_data`        | User defined metadata string                               |                 | no
-`vlan_private`     | The ID, name or qualified name of the private VLAN         | Auto-generated  | no
-`vlan_public`      | The ID, name or qualified name of the public VLAN          | Auto-generated  | no
+Parameter           | Description                                                | Default         | Required
+------------------- | -----------------------------------------------------------| ----------------| --------
+`datacenter`        | Datacenter shortname                                       | First available | no
+`dedicated`         | Allocate a dedicated CCI (non-shared host)                 | false           | no
+`disk_capacity`     | The capacity of each disk                                  |                 | no **
+`domain`            | The domain of the instance                                 |                 | yes
+`force_private_ip`  | Use private IP for communication even if public IP is set  | false           | no
+`hostname`          | The hostname of the instance                               |                 | yes *
+`hourly_billing`    | Hourly billing type (false for monthly)                    | true            | no
+`image_guid`        | The global identifier for the compute or flex image to use |                 | no **
+`local_disk`        | Use a local disk (false for SAN)                           | true            | no
+`max_memory`        | The amount of RAM of the instance in Mb                    | 1024            | no
+`network_speed`     | Network port speed in Mbps                                 | 10              | no
+`operating_system`  | The instance operating system identifier                   | UBUNTU_LATEST   | no **
+`post_install`      | URI of Post-install script to download                     |                 | no
+`private_only`      | Only create access to the private network                  | false           | no
+`provision_timeout` | Provisioning wait timeout in seconds                       | 1200            | no
+`rebuild_timeout`   | Rebuild wait timeout in seconds                            | 1200            | no
+`ssh_key`           | ID or label of the SSH key(s) to provision                 |                 | yes
+`start_cpus`        | The number of processors of the instance                   | 1               | no
+`user_data`         | User defined metadata string                               |                 | no
+`vlan_private`      | The ID, name or qualified name of the private VLAN         | Auto-generated  | no
+`vlan_public`       | The ID, name or qualified name of the public VLAN          | Auto-generated  | no
 
 \* The `hostname` could be specified either using `config.vm.hostname` or the provider parameter.
 

--- a/lib/vagrant-softlayer/action/wait_for_provision.rb
+++ b/lib/vagrant-softlayer/action/wait_for_provision.rb
@@ -19,8 +19,8 @@ module VagrantPlugins
 
           retry_msg = lambda { @logger.debug("Object not found, retrying in 10 seconds.") }
 
-          # 20 minutes timeout
-          Timeout::timeout(1200) do
+          # Defaults to 20 minutes timeout
+          Timeout::timeout(env[:machine].provider_config.provision_timeout) do
             @logger.debug("Checking if the newly ordered machine has been provisioned.")
             sl_warden(retry_msg, 10) do
               while env[:sl_machine].getPowerState["name"] != "Running" || env[:sl_machine].object_mask( { "provisionDate" => "" } ).getObject == {}

--- a/lib/vagrant-softlayer/action/wait_for_rebuild.rb
+++ b/lib/vagrant-softlayer/action/wait_for_rebuild.rb
@@ -15,8 +15,8 @@ module VagrantPlugins
         def call(env)
           env[:ui].info I18n.t("vagrant_softlayer.vm.wait_for_rebuild")
 
-          # 20 minutes timeout
-          Timeout::timeout(1200) do
+          # Defaults to 20 minutes timeout
+          Timeout::timeout(env[:machine].provider_config.rebuild_timeout) do
             @logger.debug("Checking if the instance has been rebuilt.")
             sl_warden do
               while env[:sl_machine].object_mask("activeTransactionCount").getObject["activeTransactionCount"] > 0

--- a/lib/vagrant-softlayer/config.rb
+++ b/lib/vagrant-softlayer/config.rb
@@ -54,6 +54,12 @@ module VagrantPlugins
       # Whether or not the instance only has access to the private network.
       attr_accessor :private_only
 
+      # The amount of time in seconds to wait for provision to complete.
+      attr_accessor :provision_timeout
+
+      # The amount of time in seconds to wait for rebuild to complete.
+      attr_accessor :rebuild_timeout
+
       # The id or name of the ssh key to be provisioned.
       attr_accessor :ssh_key
 
@@ -80,25 +86,27 @@ module VagrantPlugins
         @endpoint_url = UNSET_VALUE
         @username     = UNSET_VALUE
 
-        @datacenter       = UNSET_VALUE
-        @dedicated        = UNSET_VALUE
-        @disk_capacity    = UNSET_VALUE
-        @domain           = UNSET_VALUE
-        @force_private_ip = UNSET_VALUE
-        @hostname         = UNSET_VALUE
-        @image_guid       = UNSET_VALUE
-        @hourly_billing   = UNSET_VALUE
-        @local_disk       = UNSET_VALUE
-        @max_memory       = UNSET_VALUE
-        @network_speed    = UNSET_VALUE
-        @operating_system = UNSET_VALUE
-        @post_install     = UNSET_VALUE
-        @private_only     = UNSET_VALUE
-        @ssh_key          = UNSET_VALUE
-        @start_cpus       = UNSET_VALUE
-        @user_data        = UNSET_VALUE
-        @vlan_private     = UNSET_VALUE
-        @vlan_public      = UNSET_VALUE
+        @datacenter        = UNSET_VALUE
+        @dedicated         = UNSET_VALUE
+        @disk_capacity     = UNSET_VALUE
+        @domain            = UNSET_VALUE
+        @force_private_ip  = UNSET_VALUE
+        @hostname          = UNSET_VALUE
+        @image_guid        = UNSET_VALUE
+        @hourly_billing    = UNSET_VALUE
+        @local_disk        = UNSET_VALUE
+        @max_memory        = UNSET_VALUE
+        @network_speed     = UNSET_VALUE
+        @operating_system  = UNSET_VALUE
+        @post_install      = UNSET_VALUE
+        @private_only      = UNSET_VALUE
+        @provision_timeout = UNSET_VALUE
+        @rebuild_timeout   = UNSET_VALUE
+        @ssh_key           = UNSET_VALUE
+        @start_cpus        = UNSET_VALUE
+        @user_data         = UNSET_VALUE
+        @vlan_private      = UNSET_VALUE
+        @vlan_public       = UNSET_VALUE
 
         @load_balancers = []
         @manage_dns     = UNSET_VALUE
@@ -188,6 +196,12 @@ module VagrantPlugins
 
         # Private-network only is false by default.
         @private_only = false if @private_only == UNSET_VALUE
+
+        # The amount of time in seconds to wait for provision to complete.
+        @provision_timeout = 1200 if @provision_timeout == UNSET_VALUE
+
+        # The amount of time in seconds to wait for rebuild to complete.
+        @rebuild_timeout = 1200 if @rebuild_timeout == UNSET_VALUE
 
         # SSH key should be specified in Vagrantfile, so we set default to nil.
         @ssh_key = nil if @ssh_key == UNSET_VALUE

--- a/lib/vagrant-softlayer/plugin.rb
+++ b/lib/vagrant-softlayer/plugin.rb
@@ -29,7 +29,7 @@ module VagrantPlugins
         Config
       end
 
-      provider(:softlayer) do
+      provider(:softlayer, :parallel => true) do
         init_logging
         init_i18n
 

--- a/spec/vagrant-softlayer/config_spec.rb
+++ b/spec/vagrant-softlayer/config_spec.rb
@@ -15,25 +15,27 @@ describe VagrantPlugins::SoftLayer::Config do
     its("endpoint_url") { should eq VagrantPlugins::SoftLayer::API_PUBLIC_ENDPOINT }
     its("username")     { should be_nil }
 
-    its("datacenter")       { should be_nil }
-    its("dedicated")        { should be_false }
-    its("disk_capacity")    { should be_nil }
-    its("domain")           { should be_nil }
-    its("force_private_ip") { should be_false }
-    its("hostname")         { should be_nil }
-    its("hourly_billing")   { should be_true }
-    its("image_guid")       { should be_nil }
-    its("local_disk")       { should be_true }
-    its("max_memory")       { should eq 1024 }
-    its("network_speed")    { should eq 10 }
-    its("operating_system") { should eq "UBUNTU_LATEST" }
-    its("post_install")     { should be_nil }
-    its("private_only")     { should be_false }
-    its("ssh_key")          { should be_nil }
-    its("start_cpus")       { should eq 1 }
-    its("user_data")        { should be_nil }
-    its("vlan_private")     { should be_nil }
-    its("vlan_public")      { should be_nil }
+    its("datacenter")        { should be_nil }
+    its("dedicated")         { should be_false }
+    its("disk_capacity")     { should be_nil }
+    its("domain")            { should be_nil }
+    its("force_private_ip")  { should be_false }
+    its("hostname")          { should be_nil }
+    its("hourly_billing")    { should be_true }
+    its("image_guid")        { should be_nil }
+    its("local_disk")        { should be_true }
+    its("max_memory")        { should eq 1024 }
+    its("network_speed")     { should eq 10 }
+    its("operating_system")  { should eq "UBUNTU_LATEST" }
+    its("post_install")      { should be_nil }
+    its("private_only")      { should be_false }
+    its("provision_timeout") { should eq 1200 }
+    its("rebuild_timeout")   { should eq 1200 }
+    its("ssh_key")           { should be_nil }
+    its("start_cpus")        { should eq 1 }
+    its("user_data")         { should be_nil }
+    its("vlan_private")      { should be_nil }
+    its("vlan_public")       { should be_nil }
 
     its("load_balancers") { should eq [] }
     its("manage_dns")     { should be_false }
@@ -53,7 +55,7 @@ describe VagrantPlugins::SoftLayer::Config do
     end
 
     context "integers" do
-      [:max_memory, :network_speed, :ssh_key, :start_cpus, :vlan_private, :vlan_public].each do |attribute|
+      [:max_memory, :network_speed, :provision_timeout, :rebuild_timeout, :ssh_key, :start_cpus, :vlan_private, :vlan_public].each do |attribute|
         it "should not default #{attribute} if overridden" do
           config.send("#{attribute}=".to_sym, 999)
           config.finalize!
@@ -131,26 +133,28 @@ describe VagrantPlugins::SoftLayer::Config do
       config.api_key  = "An API key"
       config.username = "An username"
 
-      config.datacenter       = "ams01"
-      config.dedicated        = false
-      config.domain           = "example.com"
-      config.disk_capacity    = { 0 => 25 }
-      config.force_private_ip = false
-      config.hostname         = "vagrant"
-      config.hourly_billing   = true
-      config.image_guid       = nil
-      config.local_disk       = true
-      config.max_memory       = 1024
-      config.network_speed    = 10
-      config.operating_system = "UBUNTU_LATEST"
-      config.post_install     = "http://example.com/foo"
-      config.ssh_key          = ["First key", "Second key"]
-      config.start_cpus       = 1
-      config.user_data        = "some metadata"
-      config.vlan_private     = 111
-      config.vlan_public      = 222
+      config.datacenter        = "ams01"
+      config.dedicated         = false
+      config.domain            = "example.com"
+      config.disk_capacity     = { 0 => 25 }
+      config.force_private_ip  = false
+      config.hostname          = "vagrant"
+      config.hourly_billing    = true
+      config.image_guid        = nil
+      config.local_disk        = true
+      config.max_memory        = 1024
+      config.network_speed     = 10
+      config.operating_system  = "UBUNTU_LATEST"
+      config.post_install      = "http://example.com/foo"
+      config.provision_timeout = 1200
+      config.rebuild_timeout   = 1200
+      config.ssh_key           = ["First key", "Second key"]
+      config.start_cpus        = 1
+      config.user_data         = "some metadata"
+      config.vlan_private      = 111
+      config.vlan_public       = 222
 
-      config.manage_dns       = false
+      config.manage_dns        = false
 
       machine.stub_chain(:config, :vm, :hostname).and_return(nil)
     end


### PR DESCRIPTION
Note: I tested the object id's of SL API Service instances to ensure each box was creating its own instances so theres no worry here for these to be critical sections in threading.
