### PR TITLE
Fix unit tests on fresh checkout.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 
 .bundle
 pkg/*
-Gemfile.lock
 
 .rspec
 

--- a/spec/vagrant-softlayer/config_spec.rb
+++ b/spec/vagrant-softlayer/config_spec.rb
@@ -80,7 +80,7 @@ describe VagrantPlugins::SoftLayer::Config do
       it "should not default disk_capacity if overriden" do
         config.send("disk_capacity=".to_sym, { 0 => 100, 2 => 25 } )
         config.finalize!
-        expect(config.send("disk_capacity")).to eq { 0 => 100, 2 => 25 }
+        expect(config.send("disk_capacity")).to eq({ 0 => 100, 2 => 25 })
       end
     end
   end
@@ -255,6 +255,7 @@ describe VagrantPlugins::SoftLayer::Config do
     end
 
     it "should fail if operating system and image_guid are both specified" do
+      config.disk_capacity = nil
       config.image_guid = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
       config.operating_system = "UBUNTU_LATEST"
       config.finalize!

--- a/vagrant-softlayer.gemspec
+++ b/vagrant-softlayer.gemspec
@@ -51,5 +51,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "<2.99"
 end


### PR DESCRIPTION
`bundle exec rake` should run with no errors on ruby-2.0.0-p353 which is
the same version embedded in vagrant 1.6.5 on Windows.
