### PR TITLE
Fix NoMethodError at ip_address_record method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 
 .bundle
+bundle
 pkg/*
 Gemfile.lock
 .rspec


### PR DESCRIPTION
`ip_address_record` should retry `getObject` for the new instance that haven't had any networkComponent.