### PR TITLE
[contrib] Vagrant softlayer credentials manager

### DIFF
--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -244,6 +244,17 @@ module SoftLayer
         return software_passwords
       end
 
+      def self.object_filter_criteria_contains(object_filter, filter_path, contains_data)
+        object_filter.set_criteria_for_key_path(filter_path,
+                                                {
+                                                  'operation' => 'in',
+                                                  'options' => [{
+                                                                  'name' => 'data',
+                                                                  'value' => contains_data.collect{ |filter_value| filter_value.to_s }
+                                                                }]
+                                                })
+      end
+
       def self.pretty_print_table(table)
         max_col_widths = table.transpose.map { |col| col.group_by(&:size).max.first + 2 }
         print ':' + max_col_widths.map { |col_width| '.' * col_width}.join(':' ) + ":\n:"
@@ -361,27 +372,14 @@ module SoftLayer
             if options[:filter][option] && ! options[:filter][option].empty?
               next if option == :username && filter_type == :add
 
-              software_object_filter.set_criteria_for_key_path(filter_path,
-                                                               {
-                                                                 'operation' => 'in',
-                                                                 'options' => [{
-                                                                                 'name' => 'data',
-                                                                                 'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
-                                                                               }]
-                                                               })
+              object_filter_criteria_contains(software_object_filter, filter_path, options[:filter][option])
             end
           end
 
           option_to_filter_path[:software_password].each do |option, filter_path|
             if options[:filter][option] && ! options[:filter][option].empty?
-              software_password_object_filter.set_criteria_for_key_path(filter_path,
-                                                                        {
-                                                                          'operation' => 'in',
-                                                                          'options' => [{
-                                                                                          'name' => 'data',
-                                                                                          'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
-                                                                                        }]
-                                                                        })
+
+              object_filter_criteria_contains(software_password_object_filter, filter_path, options[:filter][option])
             end
           end
 
@@ -393,14 +391,7 @@ module SoftLayer
             hardware_types.each do |hardware_type|
               option_to_filter_path[:hardware].each do |option, filter_path|
                 if options[:filter][option] && ! options[:filter][option].empty?
-                  hardware_object_filter[hardware_type].set_criteria_for_key_path(filter_path.call(hardware_type),
-                                                                                  {
-                                                                                    'operation' => 'in',
-                                                                                    'options' => [{
-                                                                                                    'name' => 'data',
-                                                                                                    'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
-                                                                                                  }]
-                                                                                  })
+                  object_filter_criteria_contains(hardware_object_filter[hardware_type], filter_path.call(hardware_type),  options[:filter][option])
                 end
               end
             end
@@ -409,14 +400,7 @@ module SoftLayer
           if list_virtual_server_passwords
             option_to_filter_path[:virtual_server].each do |option, filter_path|
               if options[:filter][option] && ! options[:filter][option].empty?
-                virtual_server_object_filter.set_criteria_for_key_path(filter_path,
-                                                                       {
-                                                                         'operation' => 'in',
-                                                                         'options' => [{
-                                                                                         'name' => 'data',
-                                                                                         'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
-                                                                                       }]
-                                                                       })
+                object_filter_criteria_contains(virtual_server_object_filter, filter_path, options[:filter][option])
               end
             end
           end

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -6,476 +6,478 @@ require 'rubygems'
 require 'softlayer_api'
 
 module SoftLayer
-  class CredentialManager
-    def self.delete_software_credentials(softlayer_client, software_password_ids, options = {})
-      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+  module Managers
+    class Credentials
+      def self.delete_software_credentials(softlayer_client, software_password_ids, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-      if ! options[:yes_prompt]
-        return false unless yes_prompt("You are deleting one or more software credentials, this cannot be undone, continue?")
+        if ! options[:yes_prompt]
+          return false unless yes_prompt("You are deleting one or more software credentials, this cannot be undone, continue?")
+        end
+
+        software_password_service = softlayer_client[:Software_Component_Password]
+        software_password_service.deleteObjects(software_password_ids.map { |sw_pw_id| { 'id' => sw_pw_id } })
+
+        return true
       end
 
-      software_password_service = softlayer_client[:Software_Component_Password]
-      software_password_service.deleteObjects(software_password_ids.map { |sw_pw_id| { 'id' => sw_pw_id } })
+      def self.list_network_message_delivery_credentials(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-      return true
-    end
+        if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+          return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
+        end
 
-    def self.list_network_message_delivery_credentials(softlayer_client, options = {})
-      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        account_service             = softlayer_client['SoftLayer_Account']
+        net_msg_deliv_accts         = [ [ 'id', 'username', 'password', 'vendor' ] ]
+        net_msg_deliv_object_filter = network_message_delivery_filters(options)
 
-      if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
-        return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
+        account_service             = account_service.object_filter(net_msg_deliv_object_filter) unless net_msg_deliv_object_filter.empty?
+        account_service             = account_service.object_mask(network_message_delivery_mask)
+        net_msg_deliv_accts_details = account_service.getNetworkMessageDeliveryAccounts
+
+        net_msg_deliv_accts_details.each do |net_msg_deliv_acct|
+          net_msg_deliv_accts.push([ net_msg_deliv_acct['id'].to_s, net_msg_deliv_acct['username'], net_msg_deliv_acct['password'], net_msg_deliv_acct['vendor']['name'] ])
+        end
+
+        pretty_print_table(net_msg_deliv_accts)
+
+        return true
       end
 
-      account_service             = softlayer_client['SoftLayer_Account']
-      net_msg_deliv_accts         = [ [ 'id', 'username', 'password', 'vendor' ] ]
-      net_msg_deliv_object_filter = network_message_delivery_filters(options)
+      def self.list_software_credential_details(softlayer_client, software_password_ids)
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-      account_service             = account_service.object_filter(net_msg_deliv_object_filter) unless net_msg_deliv_object_filter.empty?
-      account_service             = account_service.object_mask(network_message_delivery_mask)
-      net_msg_deliv_accts_details = account_service.getNetworkMessageDeliveryAccounts
+        software_password_ids.each do |sw_pw_id|
+          software_password_details = [ [ 'name', 'value' ] ]
 
-      net_msg_deliv_accts_details.each do |net_msg_deliv_acct|
-        net_msg_deliv_accts.push([ net_msg_deliv_acct['id'].to_s, net_msg_deliv_acct['username'], net_msg_deliv_acct['password'], net_msg_deliv_acct['vendor']['name'] ])
+          software_password_service = softlayer_client[:Software_Component_Password].object_with_id(sw_pw_id)
+          software_password_service = software_password_service.object_mask(software_password_mask(:"list-details"))
+
+          software_password         = software_password_service.getObject
+          server_type               = software_password['software'].has_key?('hardware') ? 'hardware' : 'virtualGuest'
+          required_user             = software_password['username'] == software_password['software']['softwareDescription']['requiredUser'] ? 'YES' : 'NO'
+
+          software_password_details.push([ 'id',            software_password['id'].to_s ])
+          software_password_details.push([ 'username',      software_password['username'] ])
+          software_password_details.push([ 'password',      software_password['password'] ])
+          software_password_details.push([ 'last modified', software_password['modifyDate'] ])
+          software_password_details.push([ 'port',          software_password['port'] || "" ])
+          software_password_details.push([ 'notes',         software_password['notes'] || "" ])
+          software_password_details.push([ 'required user', required_user ])
+          software_password_details.push([ 'description',   software_password['software']['softwareDescription']['longDescription'] ])
+          software_password_details.push([ 'name',          software_password['software']['softwareDescription']['name'] ])
+          software_password_details.push([ 'manufacturer',  software_password['software']['softwareDescription']['manufacturer'] ])
+          software_password_details.push([ 'hostname',      software_password['software'][server_type]['hostname'] ])
+          software_password_details.push([ 'domain',        software_password['software'][server_type]['domain'] ])
+          software_password_details.push([ 'datacenter',    software_password['software'][server_type]['datacenter']['name'] ])
+          software_password_details.push([ 'server type',   software_password['software'].has_key?('hardware') ? 'Hardware' : 'Virtual Guest' ])
+          software_password_details.push([ 'tags',          software_password['software'][server_type]['tagReferences'].collect { |tag| tag['tag']['name'] }.join(", ") ])
+
+          pretty_print_table(software_password_details)
+          puts if software_password_ids.length > 1
+        end
       end
 
-      pretty_print_table(net_msg_deliv_accts)
+      def self.list_software_credentials(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-      return true
-    end
+        if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+          return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
+        end
 
-    def self.list_software_credential_details(softlayer_client, software_password_ids)
-      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        software_passwords = get_software_passwords(softlayer_client, options)
 
-      software_password_ids.each do |sw_pw_id|
-        software_password_details = [ [ 'name', 'value' ] ]
+        software_passwords.map! { |sw_pw| [ sw_pw['id'].to_s, sw_pw['software']['softwareDescription']['name'], sw_pw.username, sw_pw.password ] }
+        software_passwords.sort_by! { |element| element[1] }
+        software_passwords.unshift([ "id", "software name", "username", "password" ])
 
-        software_password_service = softlayer_client[:Software_Component_Password].object_with_id(sw_pw_id)
-        software_password_service = software_password_service.object_mask(software_password_mask(:"list-details"))
+        pretty_print_table(software_passwords)
 
-        software_password         = software_password_service.getObject
-        server_type               = software_password['software'].has_key?('hardware') ? 'hardware' : 'virtualGuest'
-        required_user             = software_password['username'] == software_password['software']['softwareDescription']['requiredUser'] ? 'YES' : 'NO'
-
-        software_password_details.push([ 'id',            software_password['id'].to_s ])
-        software_password_details.push([ 'username',      software_password['username'] ])
-        software_password_details.push([ 'password',      software_password['password'] ])
-        software_password_details.push([ 'last modified', software_password['modifyDate'] ])
-        software_password_details.push([ 'port',          software_password['port'] || "" ])
-        software_password_details.push([ 'notes',         software_password['notes'] || "" ])
-        software_password_details.push([ 'required user', required_user ])
-        software_password_details.push([ 'description',   software_password['software']['softwareDescription']['longDescription'] ])
-        software_password_details.push([ 'name',          software_password['software']['softwareDescription']['name'] ])
-        software_password_details.push([ 'manufacturer',  software_password['software']['softwareDescription']['manufacturer'] ])
-        software_password_details.push([ 'hostname',      software_password['software'][server_type]['hostname'] ])
-        software_password_details.push([ 'domain',        software_password['software'][server_type]['domain'] ])
-        software_password_details.push([ 'datacenter',    software_password['software'][server_type]['datacenter']['name'] ])
-        software_password_details.push([ 'server type',   software_password['software'].has_key?('hardware') ? 'Hardware' : 'Virtual Guest' ])
-        software_password_details.push([ 'tags',          software_password['software'][server_type]['tagReferences'].collect { |tag| tag['tag']['name'] }.join(", ") ])
-
-        pretty_print_table(software_password_details)
-        puts if software_password_ids.length > 1
-      end
-    end
-
-    def self.list_software_credentials(softlayer_client, options = {})
-      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
-
-      if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
-        return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
+        return true
       end
 
-      software_passwords = get_software_passwords(softlayer_client, options)
+      def self.set_network_message_delivery_credentials(softlayer_client, password, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-      software_passwords.map! { |sw_pw| [ sw_pw['id'].to_s, sw_pw['software']['softwareDescription']['name'], sw_pw.username, sw_pw.password ] }
-      software_passwords.sort_by! { |element| element[1] }
-      software_passwords.unshift([ "id", "software name", "username", "password" ])
+        if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+          return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
+        end
 
-      pretty_print_table(software_passwords)
+        if ! options[:yes_prompt]
+          return false unless yes_prompt("You are setting one or more network message delivery credentials, this cannot be undone, continue?")
+        end
 
-      return true
-    end
+        account_service             = softlayer_client['SoftLayer_Account']
+        net_msg_deliv_object_filter = network_message_delivery_filters(options)
 
-    def self.set_network_message_delivery_credentials(softlayer_client, password, options = {})
-      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        account_service             = account_service.object_filter(net_msg_deliv_object_filter) unless net_msg_deliv_object_filter.empty?
+        account_service             = account_service.object_mask(SoftLayer::NetworkMessageDelivery.default_object_mask)
+        net_msg_deliv_accts         = account_service.getNetworkMessageDeliveryAccounts.collect{|net_msg_deliv_acct| SoftLayer::NetworkMessageDelivery.new(softlayer_client, net_msg_deliv_acct)}
 
-      if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
-        return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
+        net_msg_deliv_accts.each{|net_msg_deliv_acct| net_msg_deliv_acct.password= password}
+
+        return true
       end
 
-      if ! options[:yes_prompt]
-        return false unless yes_prompt("You are setting one or more network message delivery credentials, this cannot be undone, continue?")
+      def self.set_software_credentials(softlayer_client, password, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+          return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
+        end
+
+        if ! options[:yes_prompt]
+          return false unless yes_prompt("You are setting one or more software credentials, this cannot be undone, continue?")
+        end
+
+        software_passwords = get_software_passwords(softlayer_client, options)
+
+        SoftLayer::SoftwarePassword.update_passwords(software_passwords, password, :client => softlayer_client)
+
+        if options[:add_user_password]
+          add_software_credentials(softlayer_client, password, options)
+        end
+
+        return true
       end
 
-      account_service             = softlayer_client['SoftLayer_Account']
-      net_msg_deliv_object_filter = network_message_delivery_filters(options)
+      private
 
-      account_service             = account_service.object_filter(net_msg_deliv_object_filter) unless net_msg_deliv_object_filter.empty?
-      account_service             = account_service.object_mask(SoftLayer::NetworkMessageDelivery.default_object_mask)
-      net_msg_deliv_accts         = account_service.getNetworkMessageDeliveryAccounts.collect{|net_msg_deliv_acct| SoftLayer::NetworkMessageDelivery.new(softlayer_client, net_msg_deliv_acct)}
+      def self.add_software_credentials(softlayer_client, password, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise "Expected a list of usernames to add software credentials for as part of filters" if ! options[:filter] || ! options[:filter][:username] || options[:filter][:username].empty?
 
-      net_msg_deliv_accts.each{|net_msg_deliv_acct| net_msg_deliv_acct.password= password}
+        hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
 
-      return true
-    end
+        add_hardware_passwords       = true
+        add_virtual_server_passwords = true
 
-    def self.set_software_credentials(softlayer_client, password, options = {})
-      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        add_hardware_passwords       = false if options[:filter] && options[:filter][:virtual_servers_only]
+        add_virtual_server_passwords = false if options[:filter] && options[:filter][:hardware_only]
 
-      if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
-        return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
-      end
+        if add_hardware_passwords && (options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?)
+          hardware_types             = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
+        end
 
-      if ! options[:yes_prompt]
-        return false unless yes_prompt("You are setting one or more software credentials, this cannot be undone, continue?")
-      end
+        object_filters               = software_password_filters(:add, options)
 
-      software_passwords = get_software_passwords(softlayer_client, options)
+        software                     = []
 
-      SoftLayer::SoftwarePassword.update_passwords(software_passwords, password, :client => softlayer_client)
+        if add_hardware_passwords
+          hardware_types.each do |hardware_type|
+            software_data = SoftLayer::Software.find_software_on_hardware(:client                 => softlayer_client,
+                                                                          :hardware_object_filter => object_filters[:hardware][hardware_type],
+                                                                          :software_object_filter => object_filters[:software],
+                                                                          :software_object_mask   => software_mask)
 
-      if options[:add_user_password]
-        add_software_credentials(softlayer_client, password, options)
-      end
+            software.concat(software_data)
+          end
+        end
 
-      return true
-    end
-
-    private
-
-    def self.add_software_credentials(softlayer_client, password, options = {})
-      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
-      raise "Expected a list of usernames to add software credentials for as part of filters" if ! options[:filter] || ! options[:filter][:username] || options[:filter][:username].empty?
-
-      hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
-
-      add_hardware_passwords       = true
-      add_virtual_server_passwords = true
-
-      add_hardware_passwords       = false if options[:filter] && options[:filter][:virtual_servers_only]
-      add_virtual_server_passwords = false if options[:filter] && options[:filter][:hardware_only]
-
-      if add_hardware_passwords && (options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?)
-        hardware_types             = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
-      end
-
-      object_filters               = software_password_filters(:add, options)
-
-      software                     = []
-
-      if add_hardware_passwords
-        hardware_types.each do |hardware_type|
-          software_data = SoftLayer::Software.find_software_on_hardware(:client                 => softlayer_client,
-                                                                        :hardware_object_filter => object_filters[:hardware][hardware_type],
-                                                                        :software_object_filter => object_filters[:software],
-                                                                        :software_object_mask   => software_mask)
+        if add_virtual_server_passwords
+          software_data = SoftLayer::Software.find_software_on_virtual_servers(:client                       => softlayer_client,
+                                                                               :software_object_filter       => object_filters[:software],
+                                                                               :software_object_mask         => software_mask,
+                                                                               :virtual_server_object_filter => object_filters[:virtual_server])
 
           software.concat(software_data)
         end
-      end
 
-      if add_virtual_server_passwords
-        software_data = SoftLayer::Software.find_software_on_virtual_servers(:client                       => softlayer_client,
-                                                                             :software_object_filter       => object_filters[:software],
-                                                                             :software_object_mask         => software_mask,
-                                                                             :virtual_server_object_filter => object_filters[:virtual_server])
-
-        software.concat(software_data)
-      end
-
-      software_passwords_template = software.map do |sw|
-        options[:filter][:username].collect do |username|
-          { 'softwareId' => sw['id'], 'password' => password.to_s, 'username' => username } if sw['passwords'] && ! sw['passwords'].map{ |pw| pw['username'] }.include?(username)
-        end
-      end
-
-      software_password_service = softlayer_client[:Software_Component_Password]
-      software_password_service.createObjects(software_passwords_template.flatten.compact)
-    end
-
-    def self.get_software_passwords(softlayer_client, options = {})
-      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
-
-      hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
-
-      list_hardware_passwords       = true
-      list_virtual_server_passwords = true
-
-      list_hardware_passwords       = false if options[:filter] && options[:filter][:virtual_servers_only]
-      list_virtual_server_passwords = false if options[:filter] && options[:filter][:hardware_only]
-
-      if list_hardware_passwords && (options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?)
-        hardware_types              = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
-      end
-
-      object_filters                = software_password_filters(:list, options)
-
-      software_passwords            = []
-
-      if list_hardware_passwords
-        hardware_types.each do |hardware_type|
-          passwords = SoftLayer::SoftwarePassword.find_passwords_for_software_on_hardware(:client                          => softlayer_client,
-                                                                                          :hardware_object_filter          => object_filters[:hardware][hardware_type],
-                                                                                          :software_object_filter          => object_filters[:software],
-                                                                                          :software_password_object_filter => object_filters[:software_password],
-                                                                                          :software_password_object_mask   => software_password_mask(:list))
-          software_passwords.concat(passwords)
-        end
-      end
-
-      if list_virtual_server_passwords
-        passwords = SoftLayer::SoftwarePassword.find_passwords_for_software_on_virtual_servers(:client                          => softlayer_client,
-                                                                                               :software_object_filter          => object_filters[:software],
-                                                                                               :software_password_object_filter => object_filters[:software_password],
-                                                                                               :software_password_object_mask   => software_password_mask(:list),
-                                                                                               :virtual_server_object_filter    => object_filters[:virtual_server])
-        software_passwords.concat(passwords)
-      end
-
-      return software_passwords
-    end
-
-    def self.pretty_print_table(table)
-      max_col_widths = table.transpose.map { |col| col.group_by(&:size).max.first + 2 }
-      print ':' + max_col_widths.map { |col_width| '.' * col_width}.join(':' ) + ":\n:"
-      table[0].each_index {|col| print table[0][col].center(max_col_widths[col]) + ':' }
-      print "\n:" + max_col_widths.map { |col_width| '.' * col_width }.join(':') + ":\n"
-      table.shift
-      table.each do |row|
-        print ':'
-        row.each_index { |col| print row[col].center(max_col_widths[col]) + ':' }
-        puts
-      end
-      puts ':' + max_col_widths.map { |col_width| '.' * col_width }.join(':') + ':'
-    end
-
-    def self.network_message_delivery_mask()
-      {
-        "mask(SoftLayer_Network_Message_Delivery)" => [
-                                                       'id',
-                                                       'password',
-                                                       'username',
-                                                       'vendor.name'
-                                                      ]
-      }.to_sl_object_mask
-    end
-
-    def self.software_mask()
-      {
-        "mask(SoftLayer_Software_Component)" => [
-                                                 'id',
-                                                 'manufacturerActivationCode',
-                                                 'manufacturerLicenseInstance',
-                                                 'passwords.username'
-                                                ]
-      }.to_sl_object_mask
-    end
-
-    def self.network_message_delivery_filters(options = {})
-      option_to_filter_path = {
-        :username => 'networkMessageDeliveryAccounts.username',
-        :vendor   => 'networkMessageDeliveryAccounts.vendor.name'
-      }
-
-      net_msg_deliv_object_filter = SoftLayer::ObjectFilter.new()
-
-      if options[:filter]
-        option_to_filter_path.each do |option, filter_path|
-          if options[:filter][option] && ! options[:filter][option].empty?
-            net_msg_deliv_object_filter.set_criteria_for_key_path(filter_path,
-                                                                  {
-                                                                    'operation' => 'in',
-                                                                    'options' => [{
-                                                                                    'name' => 'data',
-                                                                                    'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
-                                                                                  }]
-                                                                  })
-          end
-        end
-      end
-
-      return net_msg_deliv_object_filter
-    end
-
-    def self.software_password_filters(filter_type, options = {})
-      filter_label = {
-        :bare_metal_instance => "bareMetalInstances",
-        :hardware            => "hardware",
-        :network_hardware    => "networkHardware",
-        :router              => "routers"
-      }
-
-      hardware_types                  = filter_label.keys
-
-      list_hardware_passwords         = true
-      list_virtual_server_passwords   = true
-
-      hardware_object_filter          = {
-        :bare_metal_instance          => SoftLayer::ObjectFilter.new(),
-        :hardware                     => SoftLayer::ObjectFilter.new(),
-        :network_hardware             => SoftLayer::ObjectFilter.new(),
-        :router                       => SoftLayer::ObjectFilter.new()
-      }
-      software_object_filter          = SoftLayer::ObjectFilter.new()
-      software_password_object_filter = SoftLayer::ObjectFilter.new()
-      virtual_server_object_filter    = SoftLayer::ObjectFilter.new()
-
-      option_to_filter_path = {
-        :hardware          => {
-          :datacenter      => lambda { |hardware_type| return [ filter_label[hardware_type], '.datacenter.name' ].join        },
-          :domain          => lambda { |hardware_type| return [ filter_label[hardware_type], '.domain' ].join                 },
-          :hostname        => lambda { |hardware_type| return [ filter_label[hardware_type], '.hostname' ].join               },
-          :tag             => lambda { |hardware_type| return [ filter_label[hardware_type], '.tagReferences.tag.name' ].join }
-        },
-        :software          => {
-          :description     => "softwareComponents.softwareDescription.longDescription",
-          :manufacturer    => "softwareComponents.softwareDescription.manufacturer",
-          :name            => "softwareComponents.softwareDescription.name",
-          :username        => "softwareComponents.passwords.username"
-        },
-        :software_password => {
-          :username        => "passwords.username"
-        },
-        :virtual_server    => {
-          :datacenter      => "virtualGuests.datacenter.name",
-          :domain          => "virtualGuests.domain",
-          :hostname        => "virtualGuests.hostname",
-          :tag             => "virtualGuests.tagReferences.tag.name"
-        }
-      }
-
-      if options[:filter]
-        list_hardware_passwords       = false if options[:filter][:virtual_servers_only]
-        list_virtual_server_passwords = false if options[:filter][:hardware_only]
-
-        option_to_filter_path[:software].each do |option, filter_path|
-          if options[:filter][option] && ! options[:filter][option].empty?
-            next if option == :username && filter_type == :add
-
-            software_object_filter.set_criteria_for_key_path(filter_path,
-                                                             {
-                                                               'operation' => 'in',
-                                                               'options' => [{
-                                                                               'name' => 'data',
-                                                                               'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
-                                                                             }]
-                                                             })
+        software_passwords_template = software.map do |sw|
+          options[:filter][:username].collect do |username|
+            { 'softwareId' => sw['id'], 'password' => password.to_s, 'username' => username } if sw['passwords'] && ! sw['passwords'].map{ |pw| pw['username'] }.include?(username)
           end
         end
 
-        option_to_filter_path[:software_password].each do |option, filter_path|
-          if options[:filter][option] && ! options[:filter][option].empty?
-            software_password_object_filter.set_criteria_for_key_path(filter_path,
-                                                                      {
-                                                                        'operation' => 'in',
-                                                                        'options' => [{
-                                                                                        'name' => 'data',
-                                                                                        'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
-                                                                                      }]
-                                                                      })
-          end
+        software_password_service = softlayer_client[:Software_Component_Password]
+        software_password_service.createObjects(software_passwords_template.flatten.compact)
+      end
+
+      def self.get_software_passwords(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
+
+        list_hardware_passwords       = true
+        list_virtual_server_passwords = true
+
+        list_hardware_passwords       = false if options[:filter] && options[:filter][:virtual_servers_only]
+        list_virtual_server_passwords = false if options[:filter] && options[:filter][:hardware_only]
+
+        if list_hardware_passwords && (options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?)
+          hardware_types              = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
         end
+
+        object_filters                = software_password_filters(:list, options)
+
+        software_passwords            = []
 
         if list_hardware_passwords
-          if options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?
-            hardware_types = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
+          hardware_types.each do |hardware_type|
+            passwords = SoftLayer::SoftwarePassword.find_passwords_for_software_on_hardware(:client                          => softlayer_client,
+                                                                                            :hardware_object_filter          => object_filters[:hardware][hardware_type],
+                                                                                            :software_object_filter          => object_filters[:software],
+                                                                                            :software_password_object_filter => object_filters[:software_password],
+                                                                                            :software_password_object_mask   => software_password_mask(:list))
+            software_passwords.concat(passwords)
+          end
+        end
+
+        if list_virtual_server_passwords
+          passwords = SoftLayer::SoftwarePassword.find_passwords_for_software_on_virtual_servers(:client                          => softlayer_client,
+                                                                                                 :software_object_filter          => object_filters[:software],
+                                                                                                 :software_password_object_filter => object_filters[:software_password],
+                                                                                                 :software_password_object_mask   => software_password_mask(:list),
+                                                                                                 :virtual_server_object_filter    => object_filters[:virtual_server])
+          software_passwords.concat(passwords)
+        end
+
+        return software_passwords
+      end
+
+      def self.pretty_print_table(table)
+        max_col_widths = table.transpose.map { |col| col.group_by(&:size).max.first + 2 }
+        print ':' + max_col_widths.map { |col_width| '.' * col_width}.join(':' ) + ":\n:"
+        table[0].each_index {|col| print table[0][col].center(max_col_widths[col]) + ':' }
+        print "\n:" + max_col_widths.map { |col_width| '.' * col_width }.join(':') + ":\n"
+        table.shift
+        table.each do |row|
+          print ':'
+          row.each_index { |col| print row[col].center(max_col_widths[col]) + ':' }
+          puts
+        end
+        puts ':' + max_col_widths.map { |col_width| '.' * col_width }.join(':') + ':'
+      end
+
+      def self.network_message_delivery_mask()
+        {
+          "mask(SoftLayer_Network_Message_Delivery)" => [
+                                                         'id',
+                                                         'password',
+                                                         'username',
+                                                         'vendor.name'
+                                                        ]
+        }.to_sl_object_mask
+      end
+
+      def self.software_mask()
+        {
+          "mask(SoftLayer_Software_Component)" => [
+                                                   'id',
+                                                   'manufacturerActivationCode',
+                                                   'manufacturerLicenseInstance',
+                                                   'passwords.username'
+                                                  ]
+        }.to_sl_object_mask
+      end
+
+      def self.network_message_delivery_filters(options = {})
+        option_to_filter_path = {
+          :username => 'networkMessageDeliveryAccounts.username',
+          :vendor   => 'networkMessageDeliveryAccounts.vendor.name'
+        }
+
+        net_msg_deliv_object_filter = SoftLayer::ObjectFilter.new()
+
+        if options[:filter]
+          option_to_filter_path.each do |option, filter_path|
+            if options[:filter][option] && ! options[:filter][option].empty?
+              net_msg_deliv_object_filter.set_criteria_for_key_path(filter_path,
+                                                                    {
+                                                                      'operation' => 'in',
+                                                                      'options' => [{
+                                                                                      'name' => 'data',
+                                                                                      'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                                    }]
+                                                                    })
+            end
+          end
+        end
+
+        return net_msg_deliv_object_filter
+      end
+
+      def self.software_password_filters(filter_type, options = {})
+        filter_label = {
+          :bare_metal_instance => "bareMetalInstances",
+          :hardware            => "hardware",
+          :network_hardware    => "networkHardware",
+          :router              => "routers"
+        }
+
+        hardware_types                  = filter_label.keys
+
+        list_hardware_passwords         = true
+        list_virtual_server_passwords   = true
+
+        hardware_object_filter          = {
+          :bare_metal_instance          => SoftLayer::ObjectFilter.new(),
+          :hardware                     => SoftLayer::ObjectFilter.new(),
+          :network_hardware             => SoftLayer::ObjectFilter.new(),
+          :router                       => SoftLayer::ObjectFilter.new()
+        }
+        software_object_filter          = SoftLayer::ObjectFilter.new()
+        software_password_object_filter = SoftLayer::ObjectFilter.new()
+        virtual_server_object_filter    = SoftLayer::ObjectFilter.new()
+
+        option_to_filter_path = {
+          :hardware          => {
+            :datacenter      => lambda { |hardware_type| return [ filter_label[hardware_type], '.datacenter.name' ].join        },
+            :domain          => lambda { |hardware_type| return [ filter_label[hardware_type], '.domain' ].join                 },
+            :hostname        => lambda { |hardware_type| return [ filter_label[hardware_type], '.hostname' ].join               },
+            :tag             => lambda { |hardware_type| return [ filter_label[hardware_type], '.tagReferences.tag.name' ].join }
+          },
+          :software          => {
+            :description     => "softwareComponents.softwareDescription.longDescription",
+            :manufacturer    => "softwareComponents.softwareDescription.manufacturer",
+            :name            => "softwareComponents.softwareDescription.name",
+            :username        => "softwareComponents.passwords.username"
+          },
+          :software_password => {
+            :username        => "passwords.username"
+          },
+          :virtual_server    => {
+            :datacenter      => "virtualGuests.datacenter.name",
+            :domain          => "virtualGuests.domain",
+            :hostname        => "virtualGuests.hostname",
+            :tag             => "virtualGuests.tagReferences.tag.name"
+          }
+        }
+
+        if options[:filter]
+          list_hardware_passwords       = false if options[:filter][:virtual_servers_only]
+          list_virtual_server_passwords = false if options[:filter][:hardware_only]
+
+          option_to_filter_path[:software].each do |option, filter_path|
+            if options[:filter][option] && ! options[:filter][option].empty?
+              next if option == :username && filter_type == :add
+
+              software_object_filter.set_criteria_for_key_path(filter_path,
+                                                               {
+                                                                 'operation' => 'in',
+                                                                 'options' => [{
+                                                                                 'name' => 'data',
+                                                                                 'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
+                                                                               }]
+                                                               })
+            end
           end
 
-          hardware_types.each do |hardware_type|
-            option_to_filter_path[:hardware].each do |option, filter_path|
+          option_to_filter_path[:software_password].each do |option, filter_path|
+            if options[:filter][option] && ! options[:filter][option].empty?
+              software_password_object_filter.set_criteria_for_key_path(filter_path,
+                                                                        {
+                                                                          'operation' => 'in',
+                                                                          'options' => [{
+                                                                                          'name' => 'data',
+                                                                                          'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
+                                                                                        }]
+                                                                        })
+            end
+          end
+
+          if list_hardware_passwords
+            if options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?
+              hardware_types = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
+            end
+
+            hardware_types.each do |hardware_type|
+              option_to_filter_path[:hardware].each do |option, filter_path|
+                if options[:filter][option] && ! options[:filter][option].empty?
+                  hardware_object_filter[hardware_type].set_criteria_for_key_path(filter_path.call(hardware_type),
+                                                                                  {
+                                                                                    'operation' => 'in',
+                                                                                    'options' => [{
+                                                                                                    'name' => 'data',
+                                                                                                    'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
+                                                                                                  }]
+                                                                                  })
+                end
+              end
+            end
+          end
+
+          if list_virtual_server_passwords
+            option_to_filter_path[:virtual_server].each do |option, filter_path|
               if options[:filter][option] && ! options[:filter][option].empty?
-                hardware_object_filter[hardware_type].set_criteria_for_key_path(filter_path.call(hardware_type),
-                                                                                {
-                                                                                  'operation' => 'in',
-                                                                                  'options' => [{
-                                                                                                  'name' => 'data',
-                                                                                                  'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
-                                                                                                }]
-                                                                                })
+                virtual_server_object_filter.set_criteria_for_key_path(filter_path,
+                                                                       {
+                                                                         'operation' => 'in',
+                                                                         'options' => [{
+                                                                                         'name' => 'data',
+                                                                                         'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
+                                                                                       }]
+                                                                       })
               end
             end
           end
         end
 
-        if list_virtual_server_passwords
-          option_to_filter_path[:virtual_server].each do |option, filter_path|
-            if options[:filter][option] && ! options[:filter][option].empty?
-              virtual_server_object_filter.set_criteria_for_key_path(filter_path,
-                                                                     {
-                                                                       'operation' => 'in',
-                                                                       'options' => [{
-                                                                                       'name' => 'data',
-                                                                                       'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
-                                                                                     }]
-                                                                     })
-            end
+        {
+          :hardware          => hardware_object_filter,
+          :software          => software_object_filter,
+          :software_password => software_password_object_filter,
+          :virtual_server    => virtual_server_object_filter
+        }
+      end
+
+      def self.software_password_mask(mask_type)
+        case mask_type
+        when :list
+          {
+            "mask(SoftLayer_Software_Component_Password)" => [
+                                                              'createDate',
+                                                              'id',
+                                                              'modifyDate',
+                                                              'notes',
+                                                              'password',
+                                                              'port',
+                                                              'software.softwareDescription.name',
+                                                              'username'
+                                                             ]
+          }.to_sl_object_mask
+        when :"list-details"
+          {
+            "mask(SoftLayer_Software_Component_Password)" => [
+                                                              'id',
+                                                              'modifyDate',
+                                                              'notes',
+                                                              'password',
+                                                              'port',
+                                                              'software.hardware[datacenter.name, domain, hostname, tagReferences.tag.name]',
+                                                              'software.softwareDescription[longDescription, manufacturer, name, requiredUser]',
+                                                              'software.virtualGuest[datacenter.name, domain, hostname, tagReferences.tag.name]',
+                                                              'username'
+                                                             ]
+          }.to_sl_object_mask
+        end
+      end
+
+      def self.yes_prompt(prompt_message)
+        while true do
+          $stderr.print prompt_message.to_s + " (Y/N): "
+
+          case $stdin.readline().chomp!
+          when 'yes', 'y', 'Y'
+            return true
+          when 'no', 'n', 'N'
+            return false
+          else
+            next
           end
         end
       end
-
-      {
-        :hardware          => hardware_object_filter,
-        :software          => software_object_filter,
-        :software_password => software_password_object_filter,
-        :virtual_server    => virtual_server_object_filter
-      }
-    end
-
-    def self.software_password_mask(mask_type)
-      case mask_type
-      when :list
-        {
-          "mask(SoftLayer_Software_Component_Password)" => [
-                                                            'createDate',
-                                                            'id',
-                                                            'modifyDate',
-                                                            'notes',
-                                                            'password',
-                                                            'port',
-                                                            'software.softwareDescription.name',
-                                                            'username'
-                                                           ]
-        }.to_sl_object_mask
-      when :"list-details"
-        {
-          "mask(SoftLayer_Software_Component_Password)" => [
-                                                            'id',
-                                                            'modifyDate',
-                                                            'notes',
-                                                            'password',
-                                                            'port',
-                                                            'software.hardware[datacenter.name, domain, hostname, tagReferences.tag.name]',
-                                                            'software.softwareDescription[longDescription, manufacturer, name, requiredUser]',
-                                                            'software.virtualGuest[datacenter.name, domain, hostname, tagReferences.tag.name]',
-                                                            'username'
-                                                           ]
-        }.to_sl_object_mask
-      end
-    end
-
-    def self.yes_prompt(prompt_message)
-      while true do
-        $stderr.print prompt_message.to_s + " (Y/N): "
-
-        case $stdin.readline().chomp!
-        when 'yes', 'y', 'Y'
-          return true
-        when 'no', 'n', 'N'
-          return false
-        else
-          next
-        end
-      end
-    end
-  end #CredentialManager
+    end #Credentials
+  end
 end
 
 class VagrantSoftLayerCredentials
@@ -618,7 +620,7 @@ List Credential Options:
 #{@help[:std_opts]}
 HELP_NMD_LIST
 
- @help[:network_message_delivery][:set]    = <<-HELP_NMD_SET
+    @help[:network_message_delivery][:set]    = <<-HELP_NMD_SET
 Usage: #{File.basename($0)} network_message_delivery set [options] [<password>]
 
 <password> - The password to set for credential(s) matching option filters.
@@ -724,56 +726,61 @@ HELP_SW_SET_PW
 
     softlayer_client = SoftLayer::Client.new(@config[:sl_credentials])
 
-    case @config[:category]
-    when :network_message_delivery
-      case @config[:action]
-      when :list
-        list_filter            = @config[:filters]
-        list_filter[:username] = @config[:username] unless @config[:username].empty?
+    begin
+      case @config[:category]
+      when :network_message_delivery
+        case @config[:action]
+        when :list
+          list_filter            = @config[:filters]
+          list_filter[:username] = @config[:username] unless @config[:username].empty?
 
-        exit 0 unless SoftLayer::CredentialManager.list_network_message_delivery_credentials(softlayer_client,
-                                                                                             :filter     => list_filter,
-                                                                                             :yes_prompt => @config[:yes_prompt])
+          exit 0 unless SoftLayer::Managers::Credentials.list_network_message_delivery_credentials(softlayer_client,
+                                                                                                   :filter     => list_filter,
+                                                                                                   :yes_prompt => @config[:yes_prompt])
 
-      when :set
-        set_filter            = @config[:filters]
-        set_filter[:username] = @config[:username] unless @config[:username].empty?
+        when :set
+          set_filter            = @config[:filters]
+          set_filter[:username] = @config[:username] unless @config[:username].empty?
 
-        exit 0 unless SoftLayer::CredentialManager.set_network_message_delivery_credentials(softlayer_client,
-                                                                                            @config[:password],
-                                                                                            :filter     => @config[:filters],
-                                                                                            :yes_prompt => @config[:yes_prompt])
+          exit 0 unless SoftLayer::Managers::Credentials.set_network_message_delivery_credentials(softlayer_client,
+                                                                                                  @config[:password],
+                                                                                                  :filter     => @config[:filters],
+                                                                                                  :yes_prompt => @config[:yes_prompt])
 
+        end
+      when :software
+        case @config[:action]
+        when :delete
+          exit 0 unless SoftLayer::Managers::Credentials.delete_software_credentials(softlayer_client,
+                                                                                     @config[:action_args],
+                                                                                     :yes_prompt => @config[:yes_prompt])
+
+        when :list
+          list_filter            = @config[:filters]
+          list_filter[:username] = @config[:username] unless @config[:username].empty?
+
+          exit 0 unless SoftLayer::Managers::Credentials.list_software_credentials(softlayer_client,
+                                                                                   :filter     => list_filter,
+                                                                                   :yes_prompt => @config[:yes_prompt])
+
+        when :"list-details"
+          SoftLayer::Managers::Credentials.list_software_credential_details(softlayer_client, @config[:action_args])
+
+        when :set
+          set_filter            = @config[:filters]
+          set_filter[:username] = @config[:username] unless @config[:username].empty?
+
+          exit 0 unless SoftLayer::Managers:Credentials.set_software_credentials(softlayer_client,
+                                                                                 @config[:password],
+                                                                                 :add_user_password => @config[:add_user_password],
+                                                                                 :filter            => @config[:filters],
+                                                                                 :yes_prompt        => @config[:yes_prompt])
+
+        end
       end
-    when :software
-      case @config[:action]
-      when :delete
-        exit 0 unless SoftLayer::CredentialManager.delete_software_credentials(softlayer_client,
-                                                                               @config[:action_args],
-                                                                               :yes_prompt => @config[:yes_prompt])
-
-      when :list
-        list_filter            = @config[:filters]
-        list_filter[:username] = @config[:username] unless @config[:username].empty?
-
-        exit 0 unless SoftLayer::CredentialManager.list_software_credentials(softlayer_client,
-                                                                             :filter     => list_filter,
-                                                                             :yes_prompt => @config[:yes_prompt])
-
-      when :"list-details"
-        SoftLayerManager.list_software_credential_details(softlayer_client, @config[:action_args])
-
-      when :set
-        set_filter            = @config[:filters]
-        set_filter[:username] = @config[:username] unless @config[:username].empty?
-
-        exit 0 unless SoftLayer::CredentialManager.set_software_credentials(softlayer_client,
-                                                                            @config[:password],
-                                                                            :add_user_password => @config[:add_user_password],
-                                                                            :filter            => @config[:filters],
-                                                                            :yes_prompt        => @config[:yes_prompt])
-
-      end
+    rescue Exception => e
+      $stderr.puts "ERROR: Failed to perform action #{@config[:action]} on credential category #{@config[:category]}: #{e.message}"
+      exit 1
     end
   end
 

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -39,6 +39,28 @@ module SoftLayer
         return sec_questions
       end
 
+      def self.list_app_delivery_controller_credentials(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+          return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
+        end
+
+        app_delivery_controller_passwords = get_app_delivery_controller_passwords(softlayer_client, options)
+
+        software_passwords = []
+
+        app_delivery_controller_passwords.each { |management_ip, sw_pw| software_passwords.push([ sw_pw['id'].to_s, sw_pw.username, sw_pw.password, management_ip ]) }
+
+        software_passwords.sort_by! { |element| element[1] }
+        software_passwords.unshift([ "id", "username", "password", "management_ip" ])
+
+        pretty_print_table(software_passwords)
+
+        return true
+      end
+
       def self.list_network_message_delivery_credentials(softlayer_client, options = {})
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
@@ -267,6 +289,34 @@ module SoftLayer
         end
 
         softlayer_client["SoftLayer_User_Customer"].lostPassword(options[:filters][:username], options[:filters][:email])
+      end
+
+      def self.set_app_delivery_controller_credentials(softlayer_client, password, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if ! password || password.empty?
+          raise ArgumentError, "app_delivery_controller action set requires a non nil or empty password"
+        end
+
+        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+          return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
+        end
+
+        if ! options[:yes_prompt]
+          return false unless yes_prompt("You are setting one or more network application delivery controller credentials, this cannot be undone, continue?")
+        end
+
+        object_filters = app_delivery_controller_filters(options)
+
+        software_passwords = SoftLayer::SoftwarePassword.find_passwords_for_vlan_firewalls(:client                                        => softlayer_client,
+                                                                                           :application_delivery_controller_object_filter => object_filters[:app_delivery_controller],
+                                                                                           :software_password_object_filter               => object_filters[:software_password],
+                                                                                           :software_password_object_mask                 => software_password_mask(:list))
+
+        SoftLayer::SoftwarePassword.update_passwords(software_passwords, password, :client => softlayer_client)
+
+        return true
       end
 
       def self.set_network_message_delivery_credentials(softlayer_client, password, options = {})
@@ -537,6 +587,36 @@ module SoftLayer
         software_password_service.createObjects(software_passwords_template.flatten.compact)
       end
 
+      def self.get_app_delivery_controller_passwords(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        object_filters = app_delivery_controller_filters(options)
+
+        account_service = softlayer_client[:Account]
+        account_service = account_service.object_filter(object_filters[:app_delivery_controller]) unless object_filters[:app_delivery_controller].empty?
+        account_service = account_service.object_mask("mask[id,managementIpAddress]")
+
+        app_delivery_controller_data = account_service.getApplicationDeliveryControllers
+
+        app_delivery_controller_passwords = {}
+
+        app_delivery_controller_data.collect do |app_delivery_controller|
+          app_delivery_controller_service = softlayer_client[:Network_Application_Delivery_Controller].object_with_id(app_delivery_controller['id'])
+          app_delivery_controller_service = app_delivery_controller_service.object_filter(object_filters[:software_password]) unless object_filters[:software_password].empty?
+          app_delivery_controller_service = app_delivery_controller_service.object_mask(SoftLayer::SoftwarePassword.default_object_mask)
+          app_delivery_controller_service = app_delivery_controller_service.object_mask(software_password_mask(:list))
+
+          app_delivery_controller_password_data = app_delivery_controller_service.getPassword
+
+          unless app_delivery_controller_password_data.empty?
+            app_delivery_controller_passwords[app_delivery_controller['managementIpAddress']] = SoftLayer::SoftwarePassword.new(softlayer_client, app_delivery_controller_password_data)
+          end
+        end
+
+        return app_delivery_controller_passwords
+      end
+
       def self.get_network_vlan_firewall_passwords(softlayer_client, options = {})
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
@@ -772,6 +852,47 @@ module SoftLayer
                                                    'passwords.username'
                                                   ]
         }.to_sl_object_mask
+      end
+
+      def self.app_delivery_controller_filters(options = {})
+        option_to_filter_path = {
+          :app_delivery_controller => {
+            :advanced_mode     => "applicationDeliveryControllers.advancedModeFlag",
+            :datacenter        => "applicationDeliveryControllers.datacenter.name",
+            :management_ip     => "applicationDeliveryControllers.managementIpAddress",
+            :name              => "applicationDeliveryControllers.name",
+            :tags              => "applicationDeliveryControllers.tagReferences.tag.name"
+          },
+          :software_password => {
+            :username        => "password.username"
+          }
+        }
+
+        app_delivery_controller_object_filter = SoftLayer::ObjectFilter.new()
+        software_password_object_filter       = SoftLayer::ObjectFilter.new()
+
+        app_delivery_controller_object_filter.modify { |filter| filter.accept(option_to_filter_path[:app_delivery_controller][:advanced_mode]).when_it is(true) }
+
+        if options[:filters]
+          option_to_filter_path[:app_delivery_controller].each do |option, filter_path|
+            next if option == :advanced_mode
+
+            if options[:filters][option] && ! options[:filters][option].empty?
+              object_filter_criteria_contains(app_delivery_controller_object_filter, filter_path, options[:filters][option])
+            end
+          end
+
+          option_to_filter_path[:software_password].each do |option, filter_path|
+            if options[:filters][option] && ! options[:filters][option].empty?
+              object_filter_criteria_contains(software_password_object_filter, filter_path, options[:filters][option])
+            end
+          end
+        end
+
+        {
+          :app_delivery_controller => app_delivery_controller_object_filter,
+          :software_password       => software_password_object_filter
+        }
       end
 
       def self.network_message_delivery_filters(options = {})
@@ -1133,6 +1254,7 @@ class VagrantSoftLayerCredentials
                  [ '--hardware_type',         GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--hostname',        '-H', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--help',            '-h', GetoptLong::NO_ARGUMENT       ],
+                 [ '--management_ip'    '-M', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--manufacturer',    '-m', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--name',            '-n', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--password',        '-p', GetoptLong::NO_ARGUMENT       ],
@@ -1171,6 +1293,7 @@ class VagrantSoftLayerCredentials
       :yes_prompt        => false
     }
     @help = {
+      :app_delivery_controller  => {},
       :network_message_delivery => {},
       :network_vlan_firewall    => {},
       :software                 => {},
@@ -1213,6 +1336,12 @@ Usage: #{File.basename($0)} <category> <action> [<args>...] [<options>...]
 
 The following credential management categories and associated actions are available:
 
+app_delivery_controller:
+  list                              List credential username/password(s) for application delivery controller
+                                    management interface.
+  set                               Set credential username/password(s) for application delivery controller
+                                    management interface.
+
 network_message_delivery:
   list                              List credential username/password(s) for network message delivery services.
   set                               Set credential password for username(s) related to network message
@@ -1248,6 +1377,13 @@ user:
 
 #{@help[:std_opts]}
 HELP_EOM
+
+    @help[:app_delivery_controller_filters] = <<-HELP_APP_DELIV_CONTROL_FILTERS
+Application Delivery Controller Filter Options:
+
+--management_ip|-M <MANAGEMENT_IP>,...:
+    Include application delivery controller credentials whose manamange IP matches this list of IPs.
+HELP_APP_DELIV_CONTROL_FILTERS
 
     @help[:network_message_delivery_filters] = <<-HELP_NMD_FILTERS
 Network Message Delivery Filter Options:
@@ -1336,6 +1472,44 @@ Storage Filter Options:
 --virtual_servers:
     Include network storage credentials from storage associated with virtual servers only (not hardware).
 HELP_STOR_FILTERS
+
+    @help[:app_delivery_controller][:list]  = <<-HELP_APP_DELIV_CONTROL_LIST
+Usage: #{File.basename($0)} app_delivery_controller list [options]
+
+List Credential Options:
+
+--username|-u <USERNAME>,...:
+    List the application delivery controller credential(s) for these username(s) only.
+
+#{@help[:app_delivery_controller_filters]}
+#{@help[:std_opts]}
+HELP_APP_DELIV_CONTROL_LIST
+
+    @help[:app_delivery_controller][:set]   = <<-HELP_APP_DELIV_CONTROL_SET
+Usage: #{File.basename($0)} app_delivery_controller set [options] [<password>]
+
+<password> - The password to set for credential(s) matching option filters.
+
+Set Credential Options:
+
+--password|-p:
+    Prompt for password from STDIN instead of expecting password as an argument.
+    If not specified, it is expected that password is provided as an argument to
+    the action. If both the argument and this option are provided, the argument
+    takes precedence and the password will not be read.
+
+--username|-u <USERNAME>,...:
+    Set the application delivery controller credential password for these
+    username(s) only. If not specified, the password will be set for all
+    application delivery controller credentials that match other filtering
+    criteria regardless of username.
+
+--yes|-y:
+    Automatic yes to prompt(s).
+
+#{@help[:app_delivery_controller_filters]}
+#{@help[:std_opts]}
+HELP_APP_DELIV_CONTROL_SET
 
     @help[:network_message_delivery][:list] = <<-HELP_NMD_LIST
 Usage: #{File.basename($0)} network_message_delivery list [options]
@@ -1629,6 +1803,27 @@ HELP_USER_SET_SEC_ANS
 
     begin
       case @config[:category]
+      when :app_delivery_controller
+        case @config[:action]
+        when :list
+          list_filter            = @config[:filters]
+          list_filter[:username] = @config[:username] unless @config[:username].empty?
+
+          exit 1 unless SoftLayer::Managers::Credentials.list_app_delivery_controller_credentials(@softlayer_client,
+                                                                                                  :filters    => list_filter,
+                                                                                                  :yes_prompt => @config[:yes_prompt])
+
+        when :set
+          set_filter            = @config[:filters]
+          set_filter[:username] = @config[:username] unless @config[:username].empty?
+
+          exit 1 unless SoftLayer::Managers::Credentials.set_app_delivery_controller_credentials(@softlayer_client,
+                                                                                                 @config[:password],
+                                                                                                 :filters    => @config[:filters],
+                                                                                                 :yes_prompt => @config[:yes_prompt])
+
+        end
+
       when :network_message_delivery
         case @config[:action]
         when :list
@@ -1805,6 +2000,10 @@ HELP_USER_SET_SEC_ANS
     end
 
     category_actions = {
+      :app_delivery_controller  => {
+        :actions       => [ :list, :set ],
+        :accept_params => [ :set ]
+      },
       :network_message_delivery => {
         :actions       => [ :list, :set ],
         :accept_params => [ :set ]
@@ -1855,6 +2054,20 @@ HELP_USER_SET_SEC_ANS
 
       if ! @config[:help]
         case ARGV[0]
+        when "app_delivery_controller"
+          if ARGV[1] == "set"
+            if (ARGV.length == 2 && ! @config[:password_flag]) || ! [ 2, 3 ].include?(ARGV.length)
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
+              exit 2
+            end
+
+            if ARGV.length == 3
+              @config[:password] = ARGV[2].to_s
+            elsif @config[:password_flag]
+              @config[:password] = password_prompt
+            end
+          end
+
         when "network_message_delivery"
           if ARGV[1] == "set"
             if (ARGV.length == 2 && ! @config[:password_flag]) || ! [ 2, 3 ].include?(ARGV.length)
@@ -2098,7 +2311,7 @@ HELP_USER_SET_SEC_ANS
         when '--answer'
           @config[:answer_flag] = true
 
-        when '--datacenter', '--description', '--domain', '--fqdn', '--hardware_type', '--hostname', '--manufacturer', '--name', '--tag', '--type', '--vendor', '--vlan_number'
+        when '--datacenter', '--description', '--domain', '--fqdn', '--hardware_type', '--hostname', '--management_ip', '--manufacturer', '--name', '--tag', '--type', '--vendor', '--vlan_number'
           @config[:filters][opt.slice(2, opt.length - 2).to_sym] = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}
 
         when '--hardware'

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -21,6 +21,31 @@ module SoftLayer
       return true
     end
 
+    def self.list_network_message_delivery_credentials(softlayer_client, options = {})
+      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+      if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+        return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
+      end
+
+      account_service             = softlayer_client['SoftLayer_Account']
+      net_msg_deliv_accts         = [ [ 'id', 'username', 'password', 'vendor' ] ]
+      net_msg_deliv_object_filter = network_message_delivery_filters(options)
+
+      account_service             = account_service.object_filter(net_msg_deliv_object_filter) unless net_msg_deliv_object_filter.empty?
+      account_service             = account_service.object_mask(network_message_delivery_mask)
+      net_msg_deliv_accts_details = account_service.getNetworkMessageDeliveryAccounts
+
+      net_msg_deliv_accts_details.each do |net_msg_deliv_acct|
+        net_msg_deliv_accts.push([ net_msg_deliv_acct['id'].to_s, net_msg_deliv_acct['username'], net_msg_deliv_acct['password'], net_msg_deliv_acct['vendor']['name'] ])
+      end
+
+      pretty_print_table(net_msg_deliv_accts)
+
+      return true
+    end
+
     def self.list_software_credential_details(softlayer_client, software_password_ids)
       raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
       raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
@@ -71,6 +96,30 @@ module SoftLayer
       software_passwords.unshift([ "id", "software name", "username", "password" ])
 
       pretty_print_table(software_passwords)
+
+      return true
+    end
+
+    def self.set_network_message_delivery_credentials(softlayer_client, password, options = {})
+      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+      if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+        return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
+      end
+
+      if ! options[:yes_prompt]
+        return false unless yes_prompt("You are setting one or more network message delivery credentials, this cannot be undone, continue?")
+      end
+
+      account_service             = softlayer_client['SoftLayer_Account']
+      net_msg_deliv_object_filter = network_message_delivery_filters(options)
+
+      account_service             = account_service.object_filter(net_msg_deliv_object_filter) unless net_msg_deliv_object_filter.empty?
+      account_service             = account_service.object_mask(SoftLayer::NetworkMessageDelivery.default_object_mask)
+      net_msg_deliv_accts         = account_service.getNetworkMessageDeliveryAccounts.collect{|net_msg_deliv_acct| SoftLayer::NetworkMessageDelivery.new(softlayer_client, net_msg_deliv_acct)}
+
+      net_msg_deliv_accts.each{|net_msg_deliv_acct| net_msg_deliv_acct.password= password}
 
       return true
     end
@@ -208,6 +257,17 @@ module SoftLayer
       puts ':' + max_col_widths.map { |col_width| '.' * col_width }.join(':') + ':'
     end
 
+    def self.network_message_delivery_mask()
+      {
+        "mask(SoftLayer_Network_Message_Delivery)" => [
+                                                       'id',
+                                                       'password',
+                                                       'username',
+                                                       'vendor.name'
+                                                      ]
+      }.to_sl_object_mask
+    end
+
     def self.software_mask()
       {
         "mask(SoftLayer_Software_Component)" => [
@@ -217,6 +277,32 @@ module SoftLayer
                                                  'passwords.username'
                                                 ]
       }.to_sl_object_mask
+    end
+
+    def self.network_message_delivery_filters(options = {})
+      option_to_filter_path = {
+        :username => 'networkMessageDeliveryAccounts.username',
+        :vendor   => 'networkMessageDeliveryAccounts.vendor.name'
+      }
+
+      net_msg_deliv_object_filter = SoftLayer::ObjectFilter.new()
+
+      if options[:filter]
+        option_to_filter_path.each do |option, filter_path|
+          if options[:filter][option] && ! options[:filter][option].empty?
+            net_msg_deliv_object_filter.set_criteria_for_key_path(filter_path,
+                                                                  {
+                                                                    'operation' => 'in',
+                                                                    'options' => [{
+                                                                                    'name' => 'data',
+                                                                                    'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                                  }]
+                                                                  })
+          end
+        end
+      end
+
+      return net_msg_deliv_object_filter
     end
 
     def self.software_password_filters(filter_type, options = {})
@@ -412,6 +498,7 @@ class VagrantSoftLayerCredentials
                  [ '--sl_username',     '-u', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--tag',             '-T', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--username',        '-U', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--vendor',          '-v', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--virtual_servers',       GetoptLong::NO_ARGUMENT       ],
                  [ '--yes',             '-y', GetoptLong::NO_ARGUMENT       ]
                 ]
@@ -434,8 +521,10 @@ class VagrantSoftLayerCredentials
       :username          => [],
       :yes_prompt        => false
     }
-    @help            = {}
-    @help[:software] = {}
+    @help = {
+      :network_message_delivery => {},
+      :software                 => {}
+    }
 
     @help[:std_opts] = <<-HELP_STD_OPTS
 Standard Options:
@@ -473,6 +562,13 @@ software:
 #{@help[:std_opts]}
 HELP_EOM
 
+    @help[:network_message_delivery_filters] = <<-HELP_NMD_FILTERS
+Network Message Delivery Filter Options:
+
+--vendor|-v <VENDOR>,...:
+    Include network message delivery credentials whose vendor matches this list of vendors.
+HELP_NMD_FILTERS
+
     @help[:software_filters]             = <<-HELP_SW_FILTERS
 Software Filter Options:
 
@@ -506,6 +602,46 @@ Software Filter Options:
 --virtual_servers:
     Include software credentials from software on virtual servers only (not hardware).
 HELP_SW_FILTERS
+
+    @help[:network_message_delivery][:list] = <<-HELP_NMD_LIST
+Usage: #{File.basename($0)} network_message_delivery list [options]
+
+List Credential Options:
+
+--username|-u <USERNAME>,...:
+    List the network message delivery credential(s) for these username(s) only.
+
+--yes|-y:
+    Automatic yes to prompt(s).
+
+#{@help[:network_message_delivery_filters]}
+#{@help[:std_opts]}
+HELP_NMD_LIST
+
+ @help[:network_message_delivery][:set]    = <<-HELP_NMD_SET
+Usage: #{File.basename($0)} network_message_delivery set [options] [<password>]
+
+<password> - The password to set for credential(s) matching option filters.
+
+Set Credential Options:
+
+--password|-p:
+    Prompt for password from STDIN instead of expecting password as an argument.
+    If not specified, it is expected that password is provided as an argument to
+    the action. If both the argument and this option are provided, the argument
+    takes precedence and the password will not be read.
+
+--username|-u <USERNAME>,...:
+    Set the software credential password for these username(s) only. If not specified, the password
+    will be set for all software credentials that match other filtering criteria regardless
+    of username.
+
+--yes|-y:
+    Automatic yes to prompt(s).
+
+#{@help[:network_message_delivery_filters]}
+#{@help[:std_opts]}
+HELP_NMD_SET
 
     @help[:software][:delete] = <<-HELP_SW_DELETE
 Usage: #{File.basename($0)} software delete [options] <ID>...
@@ -589,6 +725,26 @@ HELP_SW_SET_PW
     softlayer_client = SoftLayer::Client.new(@config[:sl_credentials])
 
     case @config[:category]
+    when :network_message_delivery
+      case @config[:action]
+      when :list
+        list_filter            = @config[:filters]
+        list_filter[:username] = @config[:username] unless @config[:username].empty?
+
+        exit 0 unless SoftLayer::CredentialManager.list_network_message_delivery_credentials(softlayer_client,
+                                                                                             :filter     => list_filter,
+                                                                                             :yes_prompt => @config[:yes_prompt])
+
+      when :set
+        set_filter            = @config[:filters]
+        set_filter[:username] = @config[:username] unless @config[:username].empty?
+
+        exit 0 unless SoftLayer::CredentialManager.set_network_message_delivery_credentials(softlayer_client,
+                                                                                            @config[:password],
+                                                                                            :filter     => @config[:filters],
+                                                                                            :yes_prompt => @config[:yes_prompt])
+
+      end
     when :software
       case @config[:action]
       when :delete
@@ -624,46 +780,39 @@ HELP_SW_SET_PW
   private
 
   def password_prompt()
-    $stderr.print "Enter software credential password: "
+    $stderr.print "Enter credential password: "
     return $stdin.readline().chomp!
   end
 
   def proc_cli_args()
     if ARGV[0] == nil && ! @config[:help]
-      $stderr.puts "ERROR: No software credential category provided to perform action on"
+      $stderr.puts "ERROR: No credential category provided to perform action on"
       exit 2
     end
 
     case ARGV[0]
-    when "software"
-      @config[:category] = :software
+    when "network_message_delivery"
+      @config[:category] = :network_message_delivery
 
       if ARGV[1] == nil
-        $stderr.puts "ERROR: No action provided for credential category software: #{ARGV[1]}"
+        $stderr.puts "ERROR: No action provided for credential category #{ARGV[0]}"
         exit 2
       end
 
       case ARGV[1]
-      when "delete", "list", "list-details", "set"
+      when "list", "set"
         @config[:action] = ARGV[1].to_sym
 
       else
-        $stderr.puts "ERROR: Invalid action for credential category software: #{ARGV[1]}"
+        $stderr.puts "ERROR: Invalid action for credential category #{ARGV[0]}: #{ARGV[1]}"
         exit 2
 
       end
 
       case ARGV[1]
-      when "delete", "list-details"
-        if ARGV.length < 3
-          $stderr.puts "ERROR: Software action #{ARGV[1]} requires one or more software credential ID"
-          exit 2
-        end
-        @config[:action_args] = ARGV.slice(2, ARGV.length - 2)
-
       when "set"
         if ARGV.length != 3 && ! @config[:password_flag]
-          $stderr.puts "ERROR: Software action set requires a password be supplied either as an argument or read from STDIN using --password or -p option"
+          $stderr.puts "ERROR: network_message_delivery action set requires a password be supplied either as an argument or read from STDIN using --password or -p option"
           exit 2
         end
         
@@ -674,7 +823,52 @@ HELP_SW_SET_PW
         end
       else
         if ARGV.length >= 3
-          $stderr.puts "ERROR: Software action #{ARGV[1]} does not accept any arguments"
+          $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} does not accept any arguments"
+          exit 2
+        end
+
+      end
+
+    when "software"
+      @config[:category] = :software
+
+      if ARGV[1] == nil
+        $stderr.puts "ERROR: No action provided for credential category #{ARGV[0]}"
+        exit 2
+      end
+
+      case ARGV[1]
+      when "delete", "list", "list-details", "set"
+        @config[:action] = ARGV[1].to_sym
+
+      else
+        $stderr.puts "ERROR: Invalid action for credential category #{ARGV[0]}: #{ARGV[1]}"
+        exit 2
+
+      end
+
+      case ARGV[1]
+      when "delete", "list-details"
+        if ARGV.length < 3
+          $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires one or more software credential ID"
+          exit 2
+        end
+        @config[:action_args] = ARGV.slice(2, ARGV.length - 2)
+
+      when "set"
+        if ARGV.length != 3 && ! @config[:password_flag]
+          $stderr.puts "ERROR: #{ARGV[0]} action set requires a password be supplied either as an argument or read from STDIN using --password or -p option"
+          exit 2
+        end
+        
+        if ARGV.length == 3
+          @config[:password] = ARGV[2].to_s
+        elsif @config[:password_flag]
+          @config[:password] = password_prompt
+        end
+      else
+        if ARGV.length >= 3
+          $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} does not accept any arguments"
           exit 2
         end
 
@@ -682,7 +876,7 @@ HELP_SW_SET_PW
 
     else
       unless @config[:help]
-        $stderr.puts "ERROR: Invalid software credential category provided to perform action on"
+        $stderr.puts "ERROR: Invalid credential category provided to perform action on"
         exit 2
       end
 
@@ -699,7 +893,7 @@ HELP_SW_SET_PW
         when '--add'
           @config[:add_user_password] = true
 
-        when '--datacenter', '--description', '--domain', '--hardware_type', '--hostname', '--manufacturer', '--name', '--tag'
+        when '--datacenter', '--description', '--domain', '--hardware_type', '--hostname', '--manufacturer', '--name', '--tag', '--vendor'
           @config[:filters][opt.slice(2, opt.length - 2).to_sym] = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}
 
         when '--hardware'

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -1,0 +1,770 @@
+#!/usr/bin/env ruby
+
+require 'getoptlong'
+
+require 'rubygems'
+require 'softlayer_api'
+
+class SoftLayerCredentialManager
+  def self.delete_software_credentials(softlayer_client, software_password_ids, options = {})
+    raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+    raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+    if ! options[:yes_prompt]
+      exit 0 unless yes_prompt("You are deleting one or more software credentials, this cannot be undone, continue?")
+    end
+
+    software_password_service = softlayer_client[:Software_Component_Password]
+    software_password_service.deleteObjects(software_password_ids.map { |sw_pw_id| { 'id' => sw_pw_id } })
+  end
+
+  def self.list_software_credential_details(softlayer_client, software_password_ids)
+    raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+    raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+    software_password_ids.each do |sw_pw_id|
+      software_password_details = [ [ 'Name', 'Value' ] ]
+
+      software_password_service = softlayer_client[:Software_Component_Password].object_with_id(sw_pw_id)
+      software_password_service = software_password_service.object_mask(software_password_mask(:"list-details"))
+
+      software_password         = software_password_service.getObject
+      server_type               = software_password['software'].has_key?('hardware') ? 'hardware' : 'virtualGuest'
+      required_user             = software_password['username'] == software_password['software']['softwareDescription']['requiredUser'] ? 'YES' : 'NO'
+
+      software_password_details.push([ 'id',            software_password['id'].to_s ])
+      software_password_details.push([ 'username',      software_password['username'] ])
+      software_password_details.push([ 'password',      software_password['password'] ])
+      software_password_details.push([ 'last modified', software_password['modifyDate'] ])
+      software_password_details.push([ 'port',          software_password['port'] || "" ])
+      software_password_details.push([ 'notes',         software_password['notes'] || "" ])
+      software_password_details.push([ 'required user', required_user ])
+      software_password_details.push([ 'description',   software_password['software']['softwareDescription']['longDescription'] ])
+      software_password_details.push([ 'name',          software_password['software']['softwareDescription']['name'] ])
+      software_password_details.push([ 'manufacturer',  software_password['software']['softwareDescription']['manufacturer'] ])
+      software_password_details.push([ 'hostname',      software_password['software'][server_type]['hostname'] ])
+      software_password_details.push([ 'domain',        software_password['software'][server_type]['domain'] ])
+      software_password_details.push([ 'datacenter',    software_password['software'][server_type]['datacenter']['name'] ])
+      software_password_details.push([ 'server type',   software_password['software'].has_key?('hardware') ? 'Hardware' : 'Virtual Guest' ])
+      software_password_details.push([ 'tags',          software_password['software'][server_type]['tagReferences'].collect { |tag| tag['tag']['name'] }.join(", ") ])
+      
+      pretty_print_table(software_password_details)
+      puts if software_password_ids.length > 1
+    end
+  end
+
+  def self.list_software_credentials(softlayer_client, options = {})
+    raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+    raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+    if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+      exit 0 unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
+    end
+
+    software_passwords = get_software_passwords(softlayer_client, options)
+
+    software_passwords.map! { |sw_pw| [ sw_pw['id'].to_s, sw_pw['software']['softwareDescription']['name'], sw_pw.username, sw_pw.password ] }
+    software_passwords.sort_by! { |element| element[1] }
+    software_passwords.unshift([ "id", "software name", "username", "password" ])
+
+    pretty_print_table(software_passwords)
+  end
+
+  def self.set_software_credentials(softlayer_client, password, options = {})
+    raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+    raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+    if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+      exit 0 unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
+    end
+
+    if ! options[:yes_prompt]
+      exit 0 unless yes_prompt("You are setting one or more software credentials, this cannot be undone, continue?")
+    end
+
+    software_passwords = get_software_passwords(softlayer_client, options)
+
+    SoftLayer::SoftwarePassword.update_passwords(software_passwords, password, :client => softlayer_client)
+
+     if options[:add_user_password]
+      add_software_credentials(softlayer_client, password, options)
+    end
+  end
+  
+  private
+
+  def self.add_software_credentials(softlayer_client, password, options = {})
+    raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+    raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+    raise "Expected a list of usernames to add software credentials for as part of filters" if ! options[:filter] || ! options[:filter][:username] || options[:filter][:username].empty?
+
+    hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
+    
+    add_hardware_passwords       = true
+    add_virtual_server_passwords = true
+
+    add_hardware_passwords       = false if options[:filter] && options[:filter][:virtual_servers_only]
+    add_virtual_server_passwords = false if options[:filter] && options[:filter][:hardware_only]
+
+    if add_hardware_passwords && (options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?)
+      hardware_types             = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
+    end
+
+    object_filters               = software_password_filters(:add, options)
+
+    software                     = []
+
+    if add_hardware_passwords
+      hardware_types.each do |hardware_type|
+        software_data = SoftLayer::Software.find_software_on_hardware(:client                 => softlayer_client,
+                                                                      :hardware_object_filter => object_filters[:hardware][hardware_type],
+                                                                      :software_object_filter => object_filters[:software],
+                                                                      :software_object_mask   => software_mask)
+
+        software.concat(software_data)
+      end
+    end
+
+    if add_virtual_server_passwords
+      software_data = SoftLayer::Software.find_software_on_virtual_servers(:client                       => softlayer_client,
+                                                                           :software_object_filter       => object_filters[:software],
+                                                                           :software_object_mask         => software_mask,
+                                                                           :virtual_server_object_filter => object_filters[:virtual_server])
+
+      software.concat(software_data)
+    end
+    
+    software_passwords_template = software.map do |sw|
+      options[:filter][:username].collect do |username|
+        { 'softwareId' => sw['id'], 'password' => password.to_s, 'username' => username } if sw['passwords'] && ! sw['passwords'].map{ |pw| pw['username'] }.include?(username)
+      end
+    end
+
+    software_password_service = softlayer_client[:Software_Component_Password]
+    software_password_service.createObjects(software_passwords_template.flatten.compact)
+  end
+
+  def self.get_software_passwords(softlayer_client, options = {})
+    raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+    raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+    hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
+    
+    list_hardware_passwords       = true
+    list_virtual_server_passwords = true
+
+    list_hardware_passwords       = false if options[:filter] && options[:filter][:virtual_servers_only]
+    list_virtual_server_passwords = false if options[:filter] && options[:filter][:hardware_only]
+
+    if list_hardware_passwords && (options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?)
+      hardware_types              = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
+    end
+
+    object_filters                = software_password_filters(:list, options)
+    
+    software_passwords            = []
+
+    if list_hardware_passwords
+      hardware_types.each do |hardware_type|
+        passwords = SoftLayer::SoftwarePassword.find_passwords_for_software_on_hardware(:client                          => softlayer_client,
+                                                                                        :hardware_object_filter          => object_filters[:hardware][hardware_type],
+                                                                                        :software_object_filter          => object_filters[:software],
+                                                                                        :software_password_object_filter => object_filters[:software_password],
+                                                                                        :software_password_object_mask   => software_password_mask(:list))
+        software_passwords.concat(passwords)
+      end
+    end
+
+    if list_virtual_server_passwords
+      passwords = SoftLayer::SoftwarePassword.find_passwords_for_software_on_virtual_servers(:client                          => softlayer_client,
+                                                                                             :software_object_filter          => object_filters[:software],
+                                                                                             :software_password_object_filter => object_filters[:software_password],
+                                                                                             :software_password_object_mask   => software_password_mask(:list),
+                                                                                             :virtual_server_object_filter    => object_filters[:virtual_server])
+      software_passwords.concat(passwords)
+    end
+
+    return software_passwords
+  end
+
+  def self.pretty_print_table(table)
+    max_col_widths = table.transpose.map { |col| col.group_by(&:size).max.first + 2 }
+    print ':' + max_col_widths.map { |col_width| '.' * col_width}.join(':' ) + ":\n:"
+    table[0].each_index {|col| print table[0][col].center(max_col_widths[col]) + ':' }
+    print "\n:" + max_col_widths.map { |col_width| '.' * col_width }.join(':') + ":\n"
+    table.shift
+    table.each do |row|
+      print ':'
+      row.each_index { |col| print row[col].center(max_col_widths[col]) + ':' }
+      puts
+    end
+    puts ':' + max_col_widths.map { |col_width| '.' * col_width }.join(':') + ':'
+  end
+  
+  def self.software_mask()
+    {
+      "mask(SoftLayer_Software_Component)" => [
+                                               'id',
+                                               'manufacturerActivationCode',
+                                               'manufacturerLicenseInstance',
+                                               'passwords.username'
+                                              ]
+    }.to_sl_object_mask
+  end
+
+  def self.software_password_filters(filter_type, options = {})
+    filter_label = {
+      :bare_metal_instance => "bareMetalInstances",
+      :hardware            => "hardware",
+      :network_hardware    => "networkHardware",
+      :router              => "routers"
+    }
+
+    hardware_types                  = filter_label.keys
+
+    list_hardware_passwords         = true
+    list_virtual_server_passwords   = true
+
+    hardware_object_filter          = {
+      :bare_metal_instance          => SoftLayer::ObjectFilter.new(),
+      :hardware                     => SoftLayer::ObjectFilter.new(),
+      :network_hardware             => SoftLayer::ObjectFilter.new(),
+      :router                       => SoftLayer::ObjectFilter.new()
+    }
+    software_object_filter          = SoftLayer::ObjectFilter.new()
+    software_password_object_filter = SoftLayer::ObjectFilter.new()
+    virtual_server_object_filter    = SoftLayer::ObjectFilter.new()
+
+    option_to_filter_path = {
+      :hardware          => {
+        :datacenter      => lambda { |hardware_type| return [ filter_label[hardware_type], '.datacenter.name' ].join        },
+        :domain          => lambda { |hardware_type| return [ filter_label[hardware_type], '.domain' ].join                 },
+        :hostname        => lambda { |hardware_type| return [ filter_label[hardware_type], '.hostname' ].join               },
+        :tag             => lambda { |hardware_type| return [ filter_label[hardware_type], '.tagReferences.tag.name' ].join }
+      },
+      :software          => {
+        :description     => "softwareComponents.softwareDescription.longDescription",
+        :manufacturer    => "softwareComponents.softwareDescription.manufacturer",
+        :name            => "softwareComponents.softwareDescription.name",
+        :username        => "softwareComponents.passwords.username"
+      },
+      :software_password => {
+        :username        => "passwords.username"
+      },
+      :virtual_server    => {
+        :datacenter      => "virtualGuests.datacenter.name",
+        :domain          => "virtualGuests.domain",
+        :hostname        => "virtualGuests.hostname",
+        :tag             => "virtualGuests.tagReferences.tag.name"
+      }
+    }
+
+    if options[:filter]
+      list_hardware_passwords       = false if options[:filter][:virtual_servers_only]
+      list_virtual_server_passwords = false if options[:filter][:hardware_only]
+
+      option_to_filter_path[:software].each do |option, filter_path|
+        if options[:filter][option] && ! options[:filter][option].empty?
+          next if option == :username && filter_type == :add
+
+          software_object_filter.set_criteria_for_key_path(filter_path,
+                                                           {
+                                                             'operation' => 'in',
+                                                             'options' => [{
+                                                                             'name' => 'data',
+                                                                             'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                           }]
+                                                           })
+        end
+      end
+
+      option_to_filter_path[:software_password].each do |option, filter_path|
+        if options[:filter][option] && ! options[:filter][option].empty?
+          software_password_object_filter.set_criteria_for_key_path(filter_path,
+                                                                    {
+                                                                      'operation' => 'in',
+                                                                      'options' => [{
+                                                                                      'name' => 'data',
+                                                                                      'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                                    }]
+                                                                    })
+        end
+      end
+
+      if list_hardware_passwords
+        if options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?
+          hardware_types = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
+        end
+        
+        hardware_types.each do |hardware_type|
+          option_to_filter_path[:hardware].each do |option, filter_path|
+            if options[:filter][option] && ! options[:filter][option].empty?
+              hardware_object_filter[hardware_type].set_criteria_for_key_path(filter_path.call(hardware_type),
+                                                                              {
+                                                                                'operation' => 'in',
+                                                                                'options' => [{
+                                                                                                'name' => 'data',
+                                                                                                'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                                              }]
+                                                                              })
+            end
+          end
+        end
+      end
+
+      if list_virtual_server_passwords
+        option_to_filter_path[:virtual_server].each do |option, filter_path|
+            if options[:filter][option] && ! options[:filter][option].empty?
+              virtual_server_object_filter.set_criteria_for_key_path(filter_path,
+                                                                     {
+                                                                       'operation' => 'in',
+                                                                       'options' => [{
+                                                                                       'name' => 'data',
+                                                                                       'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                                     }]
+                                                                     })
+            end
+        end
+      end
+    end
+
+    { 
+      :hardware          => hardware_object_filter,
+      :software          => software_object_filter,
+      :software_password => software_password_object_filter,
+      :virtual_server    => virtual_server_object_filter
+    }
+  end
+
+  def self.software_password_mask(mask_type)
+    case mask_type
+    when :list
+      {
+        "mask(SoftLayer_Software_Component_Password)" => [
+                                                          'createDate',
+                                                          'id',
+                                                          'modifyDate',
+                                                          'notes',
+                                                          'password',
+                                                          'port',
+                                                          'software.softwareDescription.name',
+                                                          'username'
+                                                         ]
+      }.to_sl_object_mask
+    when :"list-details"
+      {
+        "mask(SoftLayer_Software_Component_Password)" => [
+                                                          'id',
+                                                          'modifyDate',
+                                                          'notes',
+                                                          'password',
+                                                          'port',
+                                                          'software.hardware[datacenter.name, domain, hostname, tagReferences.tag.name]',
+                                                          'software.softwareDescription[longDescription, manufacturer, name, requiredUser]',
+                                                          'software.virtualGuest[datacenter.name, domain, hostname, tagReferences.tag.name]',
+                                                          'username'
+                                                         ]
+      }.to_sl_object_mask
+    end
+  end
+
+  def self.yes_prompt(prompt_message)
+    while true do
+      $stderr.print prompt_message.to_s + " (Y/N): "
+      
+      case $stdin.readline().chomp!
+      when 'yes', 'y', 'Y'
+        return true
+      when 'no', 'n', 'N'
+        return false
+      else
+        next        
+      end
+    end
+  end
+end #SoftLayerCredentialManager
+
+class VagrantSoftLayerCredentials
+  def initialize()
+    @cli_opts = [
+                 [ '--add',             '-a', GetoptLong::NO_ARGUMENT       ],
+                 [ '--datacenter',      '-d', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--description',           GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--domain',          '-D', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--hardware',              GetoptLong::NO_ARGUMENT       ],
+                 [ '--hardware_type',         GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--hostname',        '-H', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--help',            '-h', GetoptLong::NO_ARGUMENT       ],
+                 [ '--manufacturer',    '-m', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--name',            '-n', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--password',        '-p', GetoptLong::NO_ARGUMENT       ],
+                 [ '--sl_api_key',      '-k', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--sl_endpoint_url', '-e', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--sl_timeout',      '-t', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--sl_username',     '-u', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--tag',             '-T', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--username',        '-U', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--virtual_servers',       GetoptLong::NO_ARGUMENT       ],
+                 [ '--yes',             '-y', GetoptLong::NO_ARGUMENT       ]
+                ]
+    @config   = {
+      :action            => nil,
+      :action_args       => [],
+      :add_user_password => false,
+      :category          => nil,
+      :filters           => {},
+      :help              => false,
+      :password          => nil,
+      :password_flag     => false,
+      :sl_credentials    => {
+        :api_key      => nil,
+        :endpoint_url => SoftLayer::API_PUBLIC_ENDPOINT,
+        :timeout      => 60,
+        :user_agent   => "vagrant-softlayer",
+        :username     => nil
+      },
+      :username          => [],
+      :yes_prompt        => false
+    }
+    @help            = {}
+    @help[:software] = {}
+
+    @help[:std_opts] = <<-HELP_STD_OPTS
+Standard Options:
+
+--help|-h:
+    Print this help.
+
+--sl_username|-u <USERNAME>:
+    Sets the SoftLayer account user name. If not specified, it is assumed SL_API_USERNAME 
+    environment variable is set.
+
+--sl_api_key|-k <SL_API_KEY>:
+    Sets the SoftLayer API key. If not specified, it is assumed SL_API_KEY environment
+    variable is set.
+
+--sl_endpoint_url|-e <SL_API_BASE_URL>:
+    Sets the SoftLayer endpoint URL. If not specified, it assumed SL_API_BASE_URL environment
+    variable is set to API_PUBLIC_ENDPOINT or API_PRIVATE_ENDPOINT.
+    Defaults to API_PUBLIC_ENDPOINT.
+HELP_STD_OPTS
+
+    @help[:help]     = <<-HELP_EOM
+Usage: #{File.basename($0)} <category> <action> [<args>...] [<options>...]
+       #{File.basename($0)} <category> <action> [-h | --help]
+       #{File.basename($0)} [-h | --help ]
+
+The following credential management categories and associated actions are available:
+
+software:
+  delete        Delete credential username/password(s) for installed software.
+  list          List credential username/password(s) for installed software.
+  list-details  List credential details for a specific username/password instance related to installed software.
+  set           Set credential password for username(s) related to installed software.
+
+#{@help[:std_opts]}
+HELP_EOM
+
+    @help[:software_filters]             = <<-HELP_SW_FILTERS
+Software Filter Options:
+
+--datacenter|-d <DATACENTER>,...:
+    Include software credentials from software on servers matching this list of datacenters.
+
+--description <DESCRIPTION>,...:
+    Include software credentials from software whose description matches this list of descriptions.
+
+--domain|-D <DOMAIN>,...:
+    Include software credentials from software on servers matching this list of domains.
+
+--hardware:
+    Include software credentials from software on hardware only (not virtual servers).
+
+--hardware_type >HARDWARE_TYPE>,...:
+    Include software credentials from software on hardware matching this list of hardware types.
+
+--hostname|-H <HOSTNAME>,...:
+    Include software credentials from software on servers matching this list of hostnames.
+
+--manufacturer|-m <MANUFACTURER>,...:
+    Include software credentials from software whose manufacturer matches this list of manufacturers.
+
+--name|-n <NAME>,...:
+    Include software credentials from software whose name matches this list of names.
+
+--tag|-T <TAG>,...:
+    Include software credentials from software on servers matching this list of tags.
+
+--virtual_servers:
+    Include software credentials from software on virtual servers only (not hardware).
+HELP_SW_FILTERS
+
+    @help[:software][:delete] = <<-HELP_SW_DELETE
+Usage: #{File.basename($0)} software delete [options] <ID>...
+
+<ID> - One or more software credential ID's to delete
+
+Delete Credential Options: 
+
+--yes|-y:
+    Automatic yes to prompt(s).
+
+#{@help[:std_opts]}
+HELP_SW_DELETE
+
+    @help[:software][:list]              = <<-HELP_SW_LIST
+Usage: #{File.basename($0)} software list [options]
+
+List Credential Options:
+
+--username|-u <USERNAME>,...:
+    List the software credential(s) for these username(s) only.
+
+--yes|-y:
+    Automatic yes to prompt(s).
+
+#{@help[:software_filters]}
+#{@help[:std_opts]}
+HELP_SW_LIST
+
+    @help[:software][:"list-details"]    = <<-HELP_SW_LIST_DETAILS
+Usage: #{File.basename($0)} software list-details [options] <ID>...
+
+<ID> - One or more software credential ID's to list details for
+
+#{@help[:std_opts]}
+HELP_SW_LIST_DETAILS
+
+    @help[:software][:set]    = <<-HELP_SW_SET_PW
+Usage: #{File.basename($0)} software set [options] [<password>]
+
+<password> - The password to set for credential(s) matching option filters.
+
+Set Credential Options:
+
+--add|-a:
+    Add the username specified to all software credential instances if not currently present.
+
+--password|-p:
+    Prompt for password from STDIN instead of expecting password as an argument.
+    If not specified, it is expected that password is provided as an argument to
+    the action. If both the argument and this option are provided, the argument
+    takes precedence and the password will not be read.
+
+--username|-u <USERNAME>,...:
+    Set the software credential password for these username(s) only. If not specified, the password
+    will be set for all software credentials that match other filtering criteria regardless
+    of username.
+
+--yes|-y:
+    Automatic yes to prompt(s).
+
+#{@help[:software_filters]}
+#{@help[:std_opts]}
+HELP_SW_SET_PW
+  end
+
+  def run()
+    proc_cli_options
+    proc_cli_args
+
+    if @config[:help]
+      if @config[:action] && @config[:category]
+        puts @help[@config[:category]][@config[:action]]
+        exit 1
+      else
+        puts @help[:help]
+        exit 1
+      end
+    end
+
+    softlayer_client = SoftLayer::Client.new(@config[:sl_credentials])
+
+    case @config[:category]
+    when :software
+      case @config[:action]
+      when :delete
+        SoftLayerCredentialManager.delete_software_credentials(softlayer_client,
+                                                               @config[:action_args],
+                                                               :yes_prompt => @config[:yes_prompt])
+
+      when :list
+        list_filter            = @config[:filters]
+        list_filter[:username] = @config[:username] unless @config[:username].empty?
+
+        SoftLayerCredentialManager.list_software_credentials(softlayer_client,
+                                                             :filter     => list_filter,
+                                                             :yes_prompt => @config[:yes_prompt])
+
+      when :"list-details"
+        SoftLayerCredentialManager.list_software_credential_details(softlayer_client, @config[:action_args])
+
+      when :set
+        set_filter            = @config[:filters]
+        set_filter[:username] = @config[:username] unless @config[:username].empty?
+
+        SoftLayerCredentialManager.set_software_credentials(softlayer_client,
+                                                            @config[:password],
+                                                            :add_user_password => @config[:add_user_password],
+                                                            :filter            => @config[:filters],
+                                                            :yes_prompt        => @config[:yes_prompt])
+
+      end
+    end
+  end
+
+  private
+
+  def password_prompt()
+    $stderr.print "Enter software credential password: "
+    return $stdin.readline().chomp!
+  end
+
+  def proc_cli_args()
+    if ARGV[0] == nil && ! @config[:help]
+      $stderr.puts "ERROR: No software credential category provided to perform action on"
+      exit 2
+    end
+
+    case ARGV[0]
+    when "software"
+      @config[:category] = :software
+
+      if ARGV[1] == nil
+        $stderr.puts "ERROR: No action provided for credential category software: #{ARGV[1]}"
+        exit 2
+      end
+
+      case ARGV[1]
+      when "delete", "list", "list-details", "set"
+        @config[:action] = ARGV[1].to_sym
+
+      else
+        $stderr.puts "ERROR: Invalid action for credential category software: #{ARGV[1]}"
+        exit 2
+
+      end
+
+      case ARGV[1]
+      when "delete", "list-details"
+        if ARGV.length < 3
+          $stderr.puts "ERROR: Software action #{ARGV[1]} requires one or more software credential ID"
+          exit 2
+        end
+        @config[:action_args] = ARGV.slice(2, ARGV.length - 2)
+
+      when "set"
+        if ARGV.length != 3 && ! @config[:password_flag]
+          $stderr.puts "ERROR: Software action set requires a password be supplied either as an argument or read from STDIN using --password or -p option"
+          exit 2
+        end
+        
+        if ARGV.length == 3
+          @config[:password] = ARGV[2].to_s
+        elsif @config[:password_flag]
+          @config[:password] = password_prompt
+        end
+      else
+        if ARGV.length >= 3
+          $stderr.puts "ERROR: Software action #{ARGV[1]} does not accept any arguments"
+          exit 2
+        end
+
+      end
+
+    else
+      unless @config[:help]
+        $stderr.puts "ERROR: Invalid software credential category provided to perform action on"
+        exit 2
+      end
+
+    end
+  end
+
+  def proc_cli_options()
+    begin
+      opts       = GetoptLong.new(*@cli_opts)
+      opts.quiet = true
+
+      opts.each do |opt, optval|
+        case opt
+        when '--add'
+          @config[:add_user_password] = true
+
+        when '--datacenter', '--description', '--domain', '--hardware_type', '--hostname', '--manufacturer', '--name', '--tag'
+          @config[:filters][opt.slice(2, opt.length - 2).to_sym] = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}
+
+        when '--hardware'
+          @config[:filters][:hardware_only] = true
+
+        when '--help'
+          @config[:help] = true
+
+        when '--password'
+          @config[:password_flag] = true
+
+        when '--sl_api_key'
+          @config[:sl_credentials][:api_key] = optval.to_s
+          
+        when '--sl_endpoint_url'
+          if ! [ "API_PUBLIC_ENDPOINT", "API_PRIVATE_ENDPOINT" ].include?(optval.to_s.upcase)
+            $stderr.puts "ERROR: Invalid endpoint_url value: " + optval.to_s.upcase
+            exit 2
+          end
+          
+          @config[:sl_credentials][:endpoint_url] = (optval.to_s.upcase == 'API_PUBLIC_ENDPOINT' ? SoftLayer::API_PUBLIC_ENDPOINT : SoftLayer::API_PRIVATE_ENDPOINT)
+
+        when '--sl_timeoout'
+          @config[:sl_credentials][:timeout] = optval.to_i
+
+        when '--sl_username'
+          @config[:sl_credentials][:username] = optval.to_s
+
+        when '--username'
+          @config[:username] = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}
+
+        when '--virtual_servers'
+          @config[:filters][:virtual_servers_only] = true
+
+        when '--yes'
+          @config[:yes_prompt] = true
+
+        end
+      end
+    rescue GetoptLong::Error => e
+      $stderr.puts "vagrant-softlayer-credentials failed to process cli options: #{ e.message }"
+      exit 1
+    end
+
+    @config[:sl_credentials][:api_key]  = ENV["SL_API_KEY"]      if @config[:sl_credentials][:api_key].nil?  && ENV.include?("SL_API_KEY")
+    @config[:sl_credentials][:username] = ENV["SL_API_USERNAME"] if @config[:sl_credentials][:username].nil? && ENV.include?("SL_API_USERNAME")
+    
+    if @config[:sl_credentials][:api_key].nil?
+      $stderr.puts "ERROR: No SoftLayer API key specified"
+      exit 2
+    end
+
+    if @config[:sl_credentials][:endpoint_url].nil? && ENV.include?("SL_API_BASE_URL")
+      if ! [ 'API_PRIVATE_ENDPOINT', 'API_PUBLIC_ENDPOINT' ].include?(ENV["SL_API_BASE_URL"])
+        $stderr.puts "ERROR: Invalid SoftLayer endpoint URL specified in environment variable SL_API_BASE_URL, expected one of #{ [ 'API_PRIVATE_ENDPOINT', 'API_PUBLIC_ENDPOINT' ].inspect }: #{ ENV["SL_API_BASE_URL"].inspect }"
+        exit 2
+      end
+
+      @config[:sl_credentials][:endpoint_url] = (ENV["SL_API_BASE_URL"] == "API_PUBLIC_ENDPOINT" ? SoftLayer::API_PUBLIC_ENDPOINT : SoftLayer::API_PRIVATE_ENDPOINT)
+    end
+    
+    if @config[:sl_credentials][:username].nil?
+      $stderr.puts "ERROR: No SoftLayer username specified"
+      exit 2
+    end
+
+    if @config[:filters][:hardware_only] && @config[:filters][:virtual_servers_only]
+      $stderr.puts "ERROR: Option filters --hardware and --virtual_servers are mutually exclusive and cannot be used at the same time"
+      exit 2
+    end
+  end
+end
+
+if __FILE__ == $0
+  VagrantSoftLayerCredentials.new.run()
+end

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -9,10 +9,10 @@ module SoftLayer
   module Managers
     class Credentials
       def self.delete_software_credentials(softlayer_client, software_password_ids, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires software password IDs"        if !software_password_ids || software_password_ids.empty?
 
-        if ! options[:yes_prompt]
+        if !options[:yes_prompt]
           return false unless yes_prompt("You are deleting one or more software credentials, this cannot be undone, continue?")
         end
 
@@ -23,12 +23,9 @@ module SoftLayer
       end
 
       def self.get_user_credentials_lost_password_sec_questions(softlayer_client, lost_password_key)
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a lost password reset key"    if !lost_password_key || lost_password_key.empty?
 
-        if ! lost_password_key || lost_password_key.empty?
-          raise ArgumentError, "A non nil or empty lost password reset key is required"
-        end
 
         account_service = SoftLayer::Account.account_for_client(softlayer_client).service
         current_user    = SoftLayer::UserCustomer.new(softlayer_client, account_service.object_mask(SoftLayer::UserCustomer.default_object_mask).getCurrentUser)
@@ -40,10 +37,9 @@ module SoftLayer
       end
 
       def self.list_app_delivery_controller_credentials(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
-        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+        if (!options[:filters] || options[:filters].empty?) && (!options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
         end
 
@@ -71,10 +67,9 @@ module SoftLayer
       end
 
       def self.list_network_message_delivery_credentials(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
-        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+        if (!options[:filters] || options[:filters].empty?) && (!options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
         end
 
@@ -100,10 +95,9 @@ module SoftLayer
       end
 
       def self.list_network_vlan_firewall_credentials(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
-        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+        if (!options[:filters] || options[:filters].empty?) && (!options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
         end
 
@@ -131,8 +125,7 @@ module SoftLayer
       end
 
       def self.list_software_credential_details(softlayer_client, software_password_ids, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
         software_password_ids.each do |sw_pw_id|
           software_password_details = [ [ 'name', 'value' ] ]
@@ -140,7 +133,12 @@ module SoftLayer
           software_password_service = softlayer_client[:Software_Component_Password].object_with_id(sw_pw_id)
           software_password_service = software_password_service.object_mask(software_password_mask(:"list-details"))
 
-          software_password         = software_password_service.getObject
+          begin
+            software_password       = software_password_service.getObject
+          rescue Exception => e
+            raise "failed to fine software password with id #{sw_pw_id}: #{e.message}"
+          end
+
           server_type               = software_password['software'].has_key?('hardware') ? 'hardware' : 'virtualGuest'
           required_user             = software_password['username'] == software_password['software']['softwareDescription']['requiredUser'] ? 'YES' : 'NO'
 
@@ -166,10 +164,9 @@ module SoftLayer
       end
 
       def self.list_software_credentials(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
-        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+        if (!options[:filters] || options[:filters].empty?) && (!options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
         end
 
@@ -195,10 +192,9 @@ module SoftLayer
       end
 
       def self.list_storage_credentials(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
-        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+        if (!options[:filters] || options[:filters].empty?) && (!options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
         end
 
@@ -250,14 +246,27 @@ module SoftLayer
       end
 
       def self.list_user_credentials(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+
+        current_user           = get_users(softlayer_client, { :filters => { :username => [ softlayer_client.username ] } }).first
+
+        raise "failed to find username #{softlayer_client.username}" if !current_user
+
+        current_user_is_master = current_user.service.isMasterUser
 
         users = get_users(softlayer_client, options).map do |user|
-          [ user['id'], [ user.last_name, ", ", user.first_name ].join, user.username, user.email, ! user['additionalEmails'].empty?, ! user['securityAnswers'].empty?, user.modified ]
+          if current_user_is_master
+            [ user['id'], [ user.last_name, ", ", user.first_name ].join, user.username, user.email, !user['additionalEmails'].empty?, !user['securityAnswers'].empty?, user.modified ]
+          else
+            [ user['id'], [ user.last_name, ", ", user.first_name ].join, user.username, user.email, !user['additionalEmails'].empty?, user.modified ]
+          end
         end
 
-        users.unshift([ 'id', 'name', 'username', 'email', 'additional emails', 'security questions used', 'last modified' ])
+        if current_user_is_master
+          users.unshift([ 'id', 'name', 'username', 'email', 'additional emails', 'security questions used', 'last modified' ])
+        else
+          users.unshift([ 'id', 'name', 'username', 'email', 'additional emails', 'last modified' ])
+        end
 
         pretty_print_table(users)
 
@@ -265,12 +274,9 @@ module SoftLayer
       end
 
       def self.list_user_credentials_lost_password_sec_questions(softlayer_client, lost_password_key)
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a lost password reset key"    if !lost_password_key || lost_password_key.empty?
 
-        if ! lost_password_key || lost_password_key.empty?
-          raise ArgumentError, "user action list-lost-password-sec-questions requires a non nil or empty lost password reset key"
-        end
 
         sec_questions = get_user_credentials_lost_password_sec_questions(softlayer_client, lost_password_key)
 
@@ -284,6 +290,8 @@ module SoftLayer
       end
 
       def self.list_user_credentials_sec_questions(softlayer_client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+
         sec_questions = softlayer_client["SoftLayer_User_Security_Question"].getAllObjects
 
         sec_questions.map! {|sec_question| [ sec_question['id'], sec_question['question'] ]}
@@ -296,8 +304,13 @@ module SoftLayer
       end
 
       def self.list_user_credential_details(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+
+        current_user           = get_users(softlayer_client, { :filters => { :username => [ softlayer_client.username ] } }).first
+
+        raise "failed to find username #{softlayer_client.username}" if !current_user
+
+        current_user_is_master = current_user.service.isMasterUser
 
         users = get_users(softlayer_client, options)
 
@@ -314,11 +327,14 @@ module SoftLayer
           user_details.push([ 'password expires',         user.password_expires                                                                       ])
           user_details.push([ 'last modified',            user.modified                                                                               ])
           user_details.push([ 'username' ,                user.username                                                                               ])
-          user_details.push([ 'api key 1',                user.api_authentication_keys[0] ? user.api_authentication_keys[0]['authenticationKey'] : "" ])
-          user_details.push([ 'api key 2',                user.api_authentication_keys[1] ? user.api_authentication_keys[1]['authenticationKey'] : "" ])
-          user_details.push([ 'security question 1 (id)', sec_questions[0] || ""                                                                      ])
-          user_details.push([ 'security question 2 (id)', sec_questions[1] || ""                                                                      ])
-          user_details.push([ 'security question 3 (id)', sec_questions[2] || ""                                                                      ])
+
+          if current_user_is_master || softlayer_client.username == user.username
+            user_details.push([ 'api key 1',                user.api_authentication_keys[0] ? user.api_authentication_keys[0]['authenticationKey'] : "" ])
+            user_details.push([ 'api key 2',                user.api_authentication_keys[1] ? user.api_authentication_keys[1]['authenticationKey'] : "" ])
+            user_details.push([ 'security question 1 (id)', sec_questions[0] || ""                                                                      ])
+            user_details.push([ 'security question 2 (id)', sec_questions[1] || ""                                                                      ])
+            user_details.push([ 'security question 3 (id)', sec_questions[2] || ""                                                                      ])
+          end
 
           pretty_print_table(user_details)
 
@@ -329,29 +345,24 @@ module SoftLayer
       end
 
       def self.send_user_credentials_lost_password_request(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
-        if ! options[:filters] || options[:filters].empty? || ! options[:filters][:email] || ! options[:filters][:username] || options[:filters][:username].empty?
-          raise ArgumentError, "user action lost-password-request requires filter options email and username"
+        if !options[:filters] || options[:filters].empty? || !options[:filters][:email] || !options[:filters][:username] || options[:filters][:username].empty?
+          raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires an email and username"
         end
 
         softlayer_client["SoftLayer_User_Customer"].lostPassword(options[:filters][:username], options[:filters][:email])
       end
 
       def self.set_app_delivery_controller_credentials(softlayer_client, password, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a password"                   if !password || password.empty?
 
-        if ! password || password.empty?
-          raise ArgumentError, "app_delivery_controller action set requires a non nil or empty password"
-        end
-
-        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+        if (!options[:filters] || options[:filters].empty?) && (!options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
         end
 
-        if ! options[:yes_prompt]
+        if !options[:yes_prompt]
           return false unless yes_prompt("You are setting one or more network application delivery controller credentials, this cannot be undone, continue?")
         end
 
@@ -368,18 +379,14 @@ module SoftLayer
       end
 
       def self.set_network_message_delivery_credentials(softlayer_client, password, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a password"                   if !password || password.empty?
 
-        if ! password || password.empty?
-          raise ArgumentError, "network_mesage_delivery action set requires a non nil or empty password"
-        end
-
-        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+        if (!options[:filters] || options[:filters].empty?) && (!options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
         end
 
-        if ! options[:yes_prompt]
+        if !options[:yes_prompt]
           return false unless yes_prompt("You are setting one or more network message delivery credentials, this cannot be undone, continue?")
         end
 
@@ -396,18 +403,14 @@ module SoftLayer
       end
 
       def self.set_network_vlan_firewall_credentials(softlayer_client, password, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a password"                   if !password || password.empty?
 
-        if ! password || password.empty?
-          raise ArgumentError, "network_vlan_firewall action set requires a non nil or empty password"
-        end
-
-        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+        if (!options[:filters] || options[:filters].empty?) && (!options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
         end
 
-        if ! options[:yes_prompt]
+        if !options[:yes_prompt]
           return false unless yes_prompt("You are setting one or more network_vlan_firewall credentials, this cannot be undone, continue?")
         end
 
@@ -428,18 +431,14 @@ module SoftLayer
       end
 
       def self.set_software_credentials(softlayer_client, password, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a password"                   if !password || password.empty?
 
-        if ! password || password.empty?
-          raise ArgumentError, "software action set requires a non nil or empty password"
-        end
-
-        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+        if (!options[:filters] || options[:filters].empty?) && (!options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
         end
 
-        if ! options[:yes_prompt]
+        if !options[:yes_prompt]
           return false unless yes_prompt("You are setting one or more software credentials, this cannot be undone, continue?")
         end
 
@@ -455,18 +454,14 @@ module SoftLayer
       end
 
       def self.set_storage_credentials(softlayer_client, password, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a password"                   if !password || password.empty?
 
-        if ! password || password.empty?
-          raise ArgumentError, "software action set requires a non nil or empty password"
-        end
-
-        if (! options[:filters] || options[:filtesr].empty?) && (! options[:yes_prompt])
+        if (!options[:filters] || options[:filtesr].empty?) && (!options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
         end
 
-        if ! options[:yes_prompt]
+        if !options[:yes_prompt]
           return false unless yes_prompt("You are setting one or more storage credentials, this cannot be undone, continue?")
         end
 
@@ -486,11 +481,11 @@ module SoftLayer
       end
 
       def self.set_user_credentials(softlayer_client, password, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance"                if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a password"                                  if !password || password.empty?
 
-        if ! password || password.empty?
-          raise ArgumentError, "user action set requires a non nil or empty password"
+        if !options[:yes_prompt]
+          return false unless yes_prompt("You are setting user #{options[:filters][:password_type]} credentials, this cannot be undone, continue?")
         end
 
         if ! options[:filters] || options[:filters].empty? || ! options[:filters][:password_type] || ! options[:filters][:username] || options[:filters][:username].empty?
@@ -503,9 +498,7 @@ module SoftLayer
 
         user = get_users(softlayer_client, options).first
 
-        if ! user
-          raise Exception, "user action set failed to find username #{options[:filters][:username].first}"
-        end
+        raise "failed to find username #{username}" if !user
 
         case options[:filters][:password_type]
         when :forum
@@ -520,29 +513,22 @@ module SoftLayer
       end
 
       def self.set_user_credentials_lost_password(softlayer_client, lost_password_key, password, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a password"                   if !password || password.empty?
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a lost password reset key"    if !lost_password_key || lost_password_key.empty?
 
-        if ! lost_password_key || lost_password_key.empty?
-          raise ArgumentError, "user action set-lost-password requires a non nil or empty lost password reset key"
+        if !options[:filters] || options[:filters].empty? || !options[:filters][:security_question_ids] ||
+             options[:filters][:security_question_ids].empty? || ![ 1, 3 ].include?(options[:filters][:security_question_ids].length)
+          raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires three security question id's that correspond to each answer"
         end
 
-        if ! password || password.empty?
-          raise ArgumentError, "user action set-lost-password requires a non nil or empty password"
-        end
-
-        if ! options[:filters] || options[:filters].empty? || ! options[:filters][:security_question_ids] ||
-             options[:filters][:security_question_ids].empty? || ! [ 1, 3 ].include?(options[:filters][:security_question_ids].length)
-          raise ArgumentError, "user action set-lost-password requires three security question id's that correspond to each answer"
-        end
-
-        if ! options[:filters] || options[:filters].empty? || ! options[:filters][:answer] ||
-             options[:filters][:answer].empty? || ! [ 1, 3 ].include?(options[:filters][:answer].length)
-          raise ArgumentError, "user action set-lost-password requires three security question answers's that correspond to each security question id"
+        if !options[:filters] || options[:filters].empty? || !options[:filters][:answer] ||
+             options[:filters][:answer].empty? || ![ 1, 3 ].include?(options[:filters][:answer].length)
+          raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires three security question answers's that correspond to each security question id"
         end
 
         if options[:filters][:answer].length != options[:filters][:security_question_ids].length
-          raise ArgumentError, "user action set-lost-password requires equal number security question answers and security question ids"
+          raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires equal number security question answers and security question ids"
         end
 
         sec_quest_answers = (0..(options[:filters][:answer].length - 1)).to_a.map do |sec_quest_index|
@@ -559,21 +545,20 @@ module SoftLayer
       end
 
       def self.set_user_credentials_sec_answers(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
-        if ! options[:filters] || options[:filters].empty? || ! options[:filters][:security_question_ids] ||
+        if !options[:filters] || options[:filters].empty? || !options[:filters][:security_question_ids] ||
             options[:filters][:security_question_ids].empty? || options[:filters][:security_question_ids].length != 3
-          raise ArgumentError, "user action set-sec-answers requires three security question id's that correspond to each answer"
+          raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires three security question id's that correspond to each answer"
         end
 
-        if ! options[:filters] || options[:filters].empty? || ! options[:filters][:answer] ||
+        if !options[:filters] || options[:filters].empty? || !options[:filters][:answer] ||
             options[:filters][:answer].empty? || options[:filters][:answer].length != 3
-          raise ArgumentError, "user action set-sec-answers requires three security question answers's that correspond to each security question id"
+          raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires three security question answers's that correspond to each security question id"
         end
 
         if options[:filters][:answer].length != options[:filters][:security_question_ids].length
-          raise ArgumentError, "user action set-sec-answers requires equal number security question answers and security question ids"
+          raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires equal number security question answers and security question ids"
         end
 
         account_service = SoftLayer::Account.account_for_client(softlayer_client).service
@@ -585,9 +570,8 @@ module SoftLayer
       private
 
       def self.add_software_credentials(softlayer_client, password, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
-        raise "Expected a list of usernames to add software credentials for as part of filters" if ! options[:filters] || ! options[:filters][:username] || options[:filters][:username].empty?
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires usernames"                    if !options[:filters] || !options[:filters][:username] || options[:filters][:username].empty?
 
         hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
 
@@ -597,7 +581,7 @@ module SoftLayer
         add_hardware_passwords       = false if options[:filters] && options[:filters][:virtual_servers_only]
         add_virtual_server_passwords = false if options[:filters] && options[:filters][:hardware_only]
 
-        if add_hardware_passwords && (options[:filters][:hardware_type] && ! options[:filters][:hardware_type].empty?)
+        if add_hardware_passwords && (options[:filters][:hardware_type] && !options[:filters][:hardware_type].empty?)
           hardware_types             = options[:filters][:hardware_type].map { |hardware_type| hardware_type.to_sym }
         end
 
@@ -627,7 +611,7 @@ module SoftLayer
 
         software_passwords_template = software.map do |sw|
           options[:filters][:username].collect do |username|
-            { 'softwareId' => sw['id'], 'password' => password.to_s, 'username' => username } if sw['passwords'] && ! sw['passwords'].map{ |pw| pw['username'] }.include?(username)
+            { 'softwareId' => sw['id'], 'password' => password.to_s, 'username' => username } if sw['passwords'] && !sw['passwords'].map{ |pw| pw['username'] }.include?(username)
           end
         end
 
@@ -636,8 +620,7 @@ module SoftLayer
       end
 
       def self.get_app_delivery_controller_passwords(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
         object_filters = app_delivery_controller_filters(options)
 
@@ -666,8 +649,7 @@ module SoftLayer
       end
 
       def self.get_network_vlan_firewall_passwords(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
         object_filters = network_vlan_firewall_filters(options)
 
@@ -711,8 +693,7 @@ module SoftLayer
       end
 
       def self.get_software_passwords(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
         hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
 
@@ -722,7 +703,7 @@ module SoftLayer
         list_hardware_passwords       = false if options[:filters] && options[:filters][:virtual_servers_only]
         list_virtual_server_passwords = false if options[:filters] && options[:filters][:hardware_only]
 
-        if list_hardware_passwords && (options[:filters][:hardware_type] && ! options[:filters][:hardware_type].empty?)
+        if list_hardware_passwords && (options[:filters][:hardware_type] && !options[:filters][:hardware_type].empty?)
           hardware_types              = options[:filters][:hardware_type].map { |hardware_type| hardware_type.to_sym }
         end
 
@@ -754,13 +735,12 @@ module SoftLayer
       end
 
       def self.get_storage(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
-        if options[:filters] && options[:filters][:type] && ! options[:filters][:type].empty?
-          storage_types                  = options[:filters][:type]
+        if options[:filters] && options[:filters][:type] && !options[:filters][:type].empty?
+          storage_types = options[:filters][:type]
         else
-          storage_types                  = [ :evault, :hub, :iscsi, :lockbox, :nas, :network_storage ]
+          storage_types = [ :evault, :hub, :iscsi, :lockbox, :nas, :network_storage ]
         end
 
         list_hardware_storage_credentials       = (options[:filters] && options[:filters][:virtual_servers_only]) ? false : true
@@ -792,9 +772,9 @@ module SoftLayer
 
         network_storage_data = network_storage_data.values
         
-        if options[:filters] && options[:filters][:username] && ! options[:filters][:username].empty?
+        if options[:filters] && options[:filters][:username] && !options[:filters][:username].empty?
           network_storage_data.delete_if do |network_storage|
-            ! (options[:filters][:username] - [ network_storage.username, network_storage.credentials.map{|cred| cred.username} ].flatten).empty?
+            !(options[:filters][:username] - [ network_storage.username, network_storage.credentials.map{|cred| cred.username} ].flatten).empty?
           end
         end
 
@@ -841,8 +821,7 @@ module SoftLayer
       end
 
       def self.get_users(softlayer_client, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
 
         account_service = SoftLayer::Account.account_for_client(softlayer_client).service
         account_service = account_service.object_filter(user_filters(options)) unless user_filters(options).empty?
@@ -854,6 +833,10 @@ module SoftLayer
       end
 
       def self.object_filter_criteria_contains(object_filter, filter_path, contains_data)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::ObjectFilter"             if !object_filter || !object_filter.kind_of?(SoftLayer::ObjectFilter)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::ObjectFilter filter path" if !filter_path || filter_path.empty?
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires SoftLayer::ObjectFilter data"          if !contains_data || contains_data.empty?
+
         object_filter.set_criteria_for_key_path(filter_path,
                                                 {
                                                   'operation' => 'in',
@@ -865,6 +848,8 @@ module SoftLayer
       end
 
       def self.pretty_print_table(table_data)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires table data" if !table_data || table_data.empty?
+
         table = table_data.dup
         table.map { |table_row| table_row.map! {|table_col| table_col.to_s } }
         max_col_widths = table.transpose.map { |col| col.group_by(&:size).max.first + 2 }
@@ -925,13 +910,13 @@ module SoftLayer
           option_to_filter_path[:app_delivery_controller].each do |option, filter_path|
             next if option == :advanced_mode
 
-            if options[:filters][option] && ! options[:filters][option].empty?
+            if options[:filters][option] && !options[:filters][option].empty?
               object_filter_criteria_contains(app_delivery_controller_object_filter, filter_path, options[:filters][option])
             end
           end
 
           option_to_filter_path[:software_password].each do |option, filter_path|
-            if options[:filters][option] && ! options[:filters][option].empty?
+            if options[:filters][option] && !options[:filters][option].empty?
               object_filter_criteria_contains(software_password_object_filter, filter_path, options[:filters][option])
             end
           end
@@ -953,7 +938,7 @@ module SoftLayer
 
         if options[:filters]
           option_to_filter_path.each do |option, filter_path|
-            if options[:filters][option] && ! options[:filters][option].empty?
+            if options[:filters][option] && !options[:filters][option].empty?
               object_filter_criteria_contains(net_msg_deliv_object_filter, filter_path, options[:filters][option])
             end
           end
@@ -996,19 +981,19 @@ module SoftLayer
 
         if options[:filters]
           option_to_filter_path[:software_password].each do |option, filter_path|
-            if options[:filters][option] && ! options[:filters][option].empty?
+            if options[:filters][option] && !options[:filters][option].empty?
               object_filter_criteria_contains(software_password_object_filter, filter_path, options[:filters][option])
             end
           end
 
           option_to_filter_path[:vlan].each do |option, filter_path|
-            if options[:filters][option] && ! options[:filters][option].empty?
+            if options[:filters][option] && !options[:filters][option].empty?
               object_filter_criteria_contains(vlan_object_filter, filter_path.call(vlan_space), options[:filters][option])
             end
           end
 
           option_to_filter_path[:vlan_firewall].each do |option, filter_path|
-            if options[:filters][option] && ! options[:filters][option].empty?
+            if options[:filters][option] && !options[:filters][option].empty?
               object_filter_criteria_contains(vlan_firewall_object_filter, filter_path, options[:filters][option])
             end
           end
@@ -1022,6 +1007,8 @@ module SoftLayer
       end
 
       def self.software_password_filters(filter_type, options = {})
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a filter type of :add or :list" if !filter_type || ![ :add, list ].include?(filter_type)
+
         filter_label = {
           :bare_metal_instance => "bareMetalInstances",
           :hardware            => "hardware",
@@ -1073,7 +1060,7 @@ module SoftLayer
           list_virtual_server_passwords = false if options[:filters][:hardware_only]
 
           option_to_filter_path[:software].each do |option, filter_path|
-            if options[:filters][option] && ! options[:filters][option].empty?
+            if options[:filters][option] && !options[:filters][option].empty?
               next if option == :username && filter_type == :add
 
               object_filter_criteria_contains(software_object_filter, filter_path, options[:filters][option])
@@ -1081,19 +1068,19 @@ module SoftLayer
           end
 
           option_to_filter_path[:software_password].each do |option, filter_path|
-            if options[:filters][option] && ! options[:filters][option].empty?
+            if options[:filters][option] && !options[:filters][option].empty?
               object_filter_criteria_contains(software_password_object_filter, filter_path, options[:filters][option])
             end
           end
 
           if list_hardware_passwords
-            if options[:filters][:hardware_type] && ! options[:filters][:hardware_type].empty?
+            if options[:filters][:hardware_type] && !options[:filters][:hardware_type].empty?
               hardware_types = options[:filters][:hardware_type].map { |hardware_type| hardware_type.to_sym }
             end
 
             hardware_types.each do |hardware_type|
               option_to_filter_path[:hardware].each do |option, filter_path|
-                if options[:filters][option] && ! options[:filters][option].empty?
+                if options[:filters][option] && !options[:filters][option].empty?
                   object_filter_criteria_contains(hardware_object_filter[hardware_type], filter_path.call(hardware_type),  options[:filters][option])
                 end
               end
@@ -1102,7 +1089,7 @@ module SoftLayer
 
           if list_virtual_server_passwords
             option_to_filter_path[:virtual_server].each do |option, filter_path|
-              if options[:filters][option] && ! options[:filters][option].empty?
+              if options[:filters][option] && !options[:filters][option].empty?
                 object_filter_criteria_contains(virtual_server_object_filter, filter_path, options[:filters][option])
               end
             end
@@ -1145,7 +1132,7 @@ module SoftLayer
           :virtual_server => {}
         }
 
-        if options[:filters] && options[:filters][:type] && ! options[:filters][:type].empty?
+        if options[:filters] && options[:filters][:type] && !options[:filters][:type].empty?
           storage_types                  = options[:filters][:type]
         else
           storage_types                  = filter_label.keys.select{|label| filter_label[label].end_with?("Storage") }
@@ -1162,7 +1149,7 @@ module SoftLayer
         if options[:filters]
           [ :datacenter, :domain, :hostname, :tags ].each do |option|
             filter_path = option_to_filter_path[option]
-            if options[:filters][option] && ! options[:filters][option].empty?
+            if options[:filters][option] && !options[:filters][option].empty?
               if list_hardware_storage_credentials
                 storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:hardware][storage_type], filter_path.call(storage_type, :hardware), options[:filters][option]) }
               end
@@ -1173,7 +1160,7 @@ module SoftLayer
             end
           end
 
-          if options[:filters][:service] && ! options[:filters][:service].empty?
+          if options[:filters][:service] && !options[:filters][:service].empty?
             if list_hardware_storage_credentials
               storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:hardware][storage_type], options_to_filter_path[:service].call(storage_type), options[:filters][:service]) }
             end
@@ -1195,7 +1182,7 @@ module SoftLayer
         user_object_filter = SoftLayer::ObjectFilter.new()
 
         if options[:filters]
-          if options[:filters][:username] && ! options[:filters][:username].empty?
+          if options[:filters][:username] && !options[:filters][:username].empty?
             object_filter_criteria_contains(user_object_filter, options_to_filter_path[:username], options[:filters][:username])
           end
         end
@@ -1218,6 +1205,7 @@ module SoftLayer
                                                               'username'
                                                              ]
           }.to_sl_object_mask
+
         when :"list-details"
           {
             "mask(SoftLayer_Software_Component_Password)" => [
@@ -1232,21 +1220,11 @@ module SoftLayer
                                                               'username'
                                                              ]
           }.to_sl_object_mask
-        end
-      end
 
-      def self.storage_credential_mask(mask_type)
-        {
-          "mask(SoftLayer_Network_Storage_Credential)" => [
-                                                           'createDate',
-                                                           'id',
-                                                           'modifyDate',
-                                                           'password',
-                                                           'type.description',
-                                                           'type.name',
-                                                           'username'
-                                                          ]
-        }.to_sl_object_mask
+        else
+          raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a mask type of :list or :list-details" if !mask_type || ![ :list, :"list-details" ].include?(mask_type)
+
+        end
       end
 
       def self.user_mask()
@@ -1272,6 +1250,8 @@ module SoftLayer
       end
 
       def self.yes_prompt(prompt_message)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a prompt message" if !prompt_message || prompt_message.empty?
+
         while true do
           $stderr.print prompt_message.to_s + " (Y/N): "
 
@@ -2071,7 +2051,7 @@ HELP_USER_SET_SEC_ANS
   end
 
   def proc_cli_args()
-    if ARGV[0] == nil && ! @config[:help]
+    if ARGV[0] == nil && !@config[:help]
       $stderr.puts "ERROR: No credential category provided to perform action on"
       exit 2
     end
@@ -2104,7 +2084,7 @@ HELP_USER_SET_SEC_ANS
     }
 
     if ARGV[0]
-      if ! category_actions.keys.include?(ARGV[0].to_sym)
+      if !category_actions.keys.include?(ARGV[0].to_sym)
         unless @config[:help]
           $stderr.puts "ERROR: Invalid credential category provided to perform action on"
           exit 2
@@ -2116,12 +2096,12 @@ HELP_USER_SET_SEC_ANS
         exit 2
       end
 
-      if ! category_actions[ARGV[0].to_sym][:actions].include?(ARGV[1].to_sym)
+      if !category_actions[ARGV[0].to_sym][:actions].include?(ARGV[1].to_sym)
         $stderr.puts "ERROR: Invalid action for credential category #{ARGV[0]}: #{ARGV[1]}"
         exit 2
       end
 
-      if ! category_actions[ARGV[0].to_sym][:accept_params].include?(ARGV[1].to_sym) && ARGV.length >= 3
+      if !category_actions[ARGV[0].to_sym][:accept_params].include?(ARGV[1].to_sym) && ARGV.length >= 3
         $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} does not accept any arguments"
         exit 2
       end
@@ -2129,11 +2109,11 @@ HELP_USER_SET_SEC_ANS
       @config[:category] = ARGV[0].to_sym if ARGV[0]
       @config[:action]   = ARGV[1].to_sym if ARGV[1]
 
-      if ! @config[:help]
+      if !@config[:help]
         case ARGV[0]
         when "app_delivery_controller"
           if ARGV[1] == "set"
-            if (ARGV.length == 2 && ! @config[:password_flag]) || ! [ 2, 3 ].include?(ARGV.length)
+            if (ARGV.length == 2 && !@config[:password_flag]) || ![ 2, 3 ].include?(ARGV.length)
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
               exit 2
             end
@@ -2147,7 +2127,7 @@ HELP_USER_SET_SEC_ANS
 
         when "network_message_delivery"
           if ARGV[1] == "set"
-            if (ARGV.length == 2 && ! @config[:password_flag]) || ! [ 2, 3 ].include?(ARGV.length)
+            if (ARGV.length == 2 && !@config[:password_flag]) || ![ 2, 3 ].include?(ARGV.length)
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
               exit 2
             end
@@ -2161,7 +2141,7 @@ HELP_USER_SET_SEC_ANS
 
         when "network_vlan_firewall"
           if ARGV[1] == "set"
-            if (ARGV.length == 2 && ! @config[:password_flag]) || ! [ 2, 3 ].include?(ARGV.length)
+            if (ARGV.length == 2 && !@config[:password_flag]) || ![ 2, 3 ].include?(ARGV.length)
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
               exit 2
             end
@@ -2184,7 +2164,7 @@ HELP_USER_SET_SEC_ANS
             @config[:filters][:credentials] = ARGV.slice(2, ARGV.length - 2)
 
           when "set"
-            if (ARGV.length == 2 && ! @config[:password_flag]) || ! [ 2, 3 ].include?(ARGV.length)
+            if (ARGV.length == 2 && !@config[:password_flag]) || ![ 2, 3 ].include?(ARGV.length)
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
               exit 2
             end
@@ -2199,7 +2179,7 @@ HELP_USER_SET_SEC_ANS
 
         when "storage"
           if ARGV[1] == "set"
-            if (ARGV.length == 2 && ! @config[:password_flag]) || ! [ 2, 3 ].include?(ARGV.length)
+            if (ARGV.length == 2 && !@config[:password_flag]) || ![ 2, 3 ].include?(ARGV.length)
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
               exit 2
             end
@@ -2239,12 +2219,12 @@ HELP_USER_SET_SEC_ANS
             @config[:username]        = ARGV[2]
 
           when "set"
-            if (ARGV.length == 4 && ! @config[:password_flag]) || ! [ 4, 6 ].include?(ARGV.length)
+            if (ARGV.length == 4 && !@config[:password_flag]) || ![ 4, 6 ].include?(ARGV.length)
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
               exit 2
             end
 
-            if ! [ :forum, :portal, :vpn ].include?(ARGV[2].to_sym)
+            if ![ :forum, :portal, :vpn ].include?(ARGV[2].to_sym)
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} has an invalid user password type, expected either forum, portal, or vpn"
               exit 2
             end
@@ -2271,7 +2251,7 @@ HELP_USER_SET_SEC_ANS
             end
 
           when "set-lost-password"
-            if ! [ 4, 5, 6, 7, 8, 9, 11 ].include?(ARGV.length)
+            if ![ 4, 5, 6, 7, 8, 9, 11 ].include?(ARGV.length)
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires passwords to be supplied either as arguments or read from STDIN using --password or -p option and " +
                            "security question answers be supplied either as arguments with the id's or read from STDIN using --answer or -A option if needed"
               exit 2
@@ -2288,7 +2268,7 @@ HELP_USER_SET_SEC_ANS
 
             sec_quest_count    = lost_password_sec_questions.length
 
-            if (sec_quest_count == 3 && ! [ 6, 8, 9, 11 ].include?(ARGV.length)) || (sec_quest_count == 1 && ! [ 4, 5, 6, 7 ].include?(ARGV.length))
+            if (sec_quest_count == 3 && ![ 6, 8, 9, 11 ].include?(ARGV.length)) || (sec_quest_count == 1 && ![ 4, 5, 6, 7 ].include?(ARGV.length))
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires passwords to be supplied either as arguments or read from STDIN using --password or -p option and " +
                            "security question answers be supplied either as arguments with the id's or read from STDIN using --answer or -A option if needed"
               exit 2
@@ -2296,14 +2276,14 @@ HELP_USER_SET_SEC_ANS
 
             password_arg_range = (sec_quest_count == 3 ? [ 8, 11 ] : [ 6, 7 ])
 
-            if ! password_arg_range.include?(ARGV.length) && ! @config[:password_flag]
+            if !password_arg_range.include?(ARGV.length) && !@config[:password_flag]
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires passwords to be supplied either as arguments or read from STDIN using --password or -p option"
               exit 2
             end
 
             answer_arg_range = (sec_quest_count == 3 ? [ 9, 11 ] : [ 5, 7 ])
 
-            if ! answer_arg_range.include?(ARGV.length) && ! @config[:answer_flag]
+            if !answer_arg_range.include?(ARGV.length) && !@config[:answer_flag]
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires security question answers be supplied either as arguments with the id's or read from STDIN using --answer or -A option if needed"
               exit 2
             end
@@ -2315,7 +2295,7 @@ HELP_USER_SET_SEC_ANS
               @config[:answer] = ARGV.slice(4, 1) if sec_quest_count == 1
             end
 
-            if ! answer_arg_range.include?(ARGV.length) && @config[:answer_flag]
+            if !answer_arg_range.include?(ARGV.length) && @config[:answer_flag]
               if sec_quest_count == 3
                 @config[:answer] = [ 
                                     answer_prompt("for security question id #{ARGV[3]}"),
@@ -2339,7 +2319,7 @@ HELP_USER_SET_SEC_ANS
             end
 
 
-            if ! password_arg_range.include?(ARGV.length) && @config[:password_flag]
+            if !password_arg_range.include?(ARGV.length) && @config[:password_flag]
               passwords = [ password_prompt, password_prompt(true) ]
 
               if passwords[0] != passwords[1]
@@ -2351,7 +2331,7 @@ HELP_USER_SET_SEC_ANS
             end
 
           when "set-sec-answers"
-            if (ARGV.length == 5 && ! @config[:answer_flag]) || ! [ 5, 8 ].include?(ARGV.length)
+            if (ARGV.length == 5 && !@config[:answer_flag]) || ![ 5, 8 ].include?(ARGV.length)
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires security question answers to be supplied either as arguments or read from STDIN using --answer or -A option"
               exit 2
             end
@@ -2407,7 +2387,7 @@ HELP_USER_SET_SEC_ANS
           @config[:sl_credentials][:api_key] = optval.to_s
           
         when '--sl_endpoint_url'
-          if ! [ "API_PUBLIC_ENDPOINT", "API_PRIVATE_ENDPOINT" ].include?(optval.to_s.upcase)
+          if ![ "API_PUBLIC_ENDPOINT", "API_PRIVATE_ENDPOINT" ].include?(optval.to_s.upcase)
             $stderr.puts "ERROR: Invalid endpoint_url value: " + optval.to_s.upcase
             exit 2
           end
@@ -2421,7 +2401,7 @@ HELP_USER_SET_SEC_ANS
           @config[:sl_credentials][:username] = optval.to_s
 
         when '--space'
-          if ! [ :all, :public, :private ].include?(optval.to_sym)
+          if ![ :all, :public, :private ].include?(optval.to_sym)
             $stderr.puts "ERROR: Network VLAN space filter must be a value of all, public, or private"
             exit 2
           end
@@ -2453,7 +2433,7 @@ HELP_USER_SET_SEC_ANS
     end
 
     if @config[:sl_credentials][:endpoint_url].nil? && ENV.include?("SL_API_BASE_URL")
-      if ! [ 'API_PRIVATE_ENDPOINT', 'API_PUBLIC_ENDPOINT' ].include?(ENV["SL_API_BASE_URL"])
+      if ![ 'API_PRIVATE_ENDPOINT', 'API_PUBLIC_ENDPOINT' ].include?(ENV["SL_API_BASE_URL"])
         $stderr.puts "ERROR: Invalid SoftLayer endpoint URL specified in environment variable SL_API_BASE_URL, expected one of #{ [ 'API_PRIVATE_ENDPOINT', 'API_PUBLIC_ENDPOINT' ].inspect }: #{ ENV["SL_API_BASE_URL"].inspect }"
         exit 2
       end

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -575,7 +575,7 @@ module SoftLayer
 
             vlan_fw_password_data = vlan_fw_service.getManagementCredentials
 
-            vlan_fw_passwords[vlan_fw['fullyQualifiedDomainName']] = SoftwarePassword.new(softlayer_client, vlan_fw_password_data) unless vlan_fw_password_data.empty?
+            vlan_fw_passwords[vlan_fw['fullyQualifiedDomainName']] = SoftLayer::SoftwarePassword.new(softlayer_client, vlan_fw_password_data) unless vlan_fw_password_data.empty?
           end
         end
 
@@ -817,9 +817,9 @@ module SoftLayer
           }
         }
 
-        software_password_object_filter = ObjectFilter.new()
-        vlan_object_filter              = ObjectFilter.new()
-        vlan_firewall_object_filter     = ObjectFilter.new()
+        software_password_object_filter = SoftLayer::ObjectFilter.new()
+        vlan_object_filter              = SoftLayer::ObjectFilter.new()
+        vlan_firewall_object_filter     = SoftLayer::ObjectFilter.new()
 
         vlan_space = (options[:filters] && options[:filters][:space]) ? options[:filters][:space] : :all
 
@@ -913,7 +913,6 @@ module SoftLayer
 
           option_to_filter_path[:software_password].each do |option, filter_path|
             if options[:filters][option] && ! options[:filters][option].empty?
-
               object_filter_criteria_contains(software_password_object_filter, filter_path, options[:filters][option])
             end
           end
@@ -1185,7 +1184,7 @@ WARNING:
  This tool is intended to simplify bulk changes to SoftLayer credentials. If you do not
  specify filters for 'set' actions the action will be taken on all available resources for
  that particular category. Be sure to test your filters using the 'list' option and provide as
- many filters as posible to narrow your selection. If you do not intend to do bulk updates,
+ many filters as possible to narrow your selection. If you do not intend to do bulk updates,
  please take a look at the functionality of the SoftLayer Python cli tool 'sl' instead.
 
 Standard Options:
@@ -1241,7 +1240,7 @@ user:
   list-details                      List credential username details for SoftLayer accounts.
   list-lost-password-sec-questions  List the questions that need to be answered when setting lost
                                     password for a SoftLayer account.
-  list-sec-questions                List available security questions for SoftLayer accounts. 
+  list-sec-questions                List available security questions for SoftLayer accounts.
   lost-password                     Send lost password reset request for key to reset a SoftLayer account.
   set                               Set credential password for username of a SoftLayer account.
   set-lost-password                 Set lost password using reset key sent in email for a SoftLayer account.

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -629,8 +629,8 @@ module SoftLayer
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-        if options[:filters] && options[:filters][:network_storage_type] && ! options[:filters][:network_storage_type].empty?
-          storage_types                  = options[:filters][:network_storage_type]
+        if options[:filters] && options[:filters][:type] && ! options[:filters][:type].empty?
+          storage_types                  = options[:filters][:type]
         else
           storage_types                  = [ :evault, :hub, :iscsi, :lockbox, :nas, :network_storage ]
         end
@@ -977,8 +977,8 @@ module SoftLayer
           :virtual_server => {}
         }
 
-        if options[:filters] && options[:filters][:network_storage_type] && ! options[:filters][:network_storage_type].empty?
-          storage_types                  = options[:filters][:network_storage_type]
+        if options[:filters] && options[:filters][:type] && ! options[:filters][:type].empty?
+          storage_types                  = options[:filters][:type]
         else
           storage_types                  = filter_label.keys.select{|label| filter_label[label].end_with?("Storage") }
         end
@@ -1142,7 +1142,6 @@ class VagrantSoftLayerCredentials
                  [ '--sl_timeout',      '-t', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--sl_username',     '-u', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--space',           '-S', GetoptLong::REQUIRED_ARGUMENT ],
-                 [ '--storage_type',    '-s', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--tag',             '-T', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--type',                  GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--username',        '-U', GetoptLong::REQUIRED_ARGUMENT ],
@@ -1329,7 +1328,7 @@ Storage Filter Options:
 --hostname|-H <HOSTNAME>,...:
     Include network storage credentials from storage whose associated servers match this list of hostnames.
 
---storage_type|-s <STORAGE_TYPE>,...:
+--type <TYPE>,...:
     Include network storage credentials from storage whose storage type match this list of storage types.
 
 --tag|-T <TAG>,...:
@@ -2100,9 +2099,8 @@ HELP_USER_SET_SEC_ANS
         when '--answer'
           @config[:answer_flag] = true
 
-        when '--datacenter', '--description', '--domain', '--fqdn', '--hardware_type', '--hostname', '--manufacturer', '--name', '--storage_type', '--tag', '--type', '--vendor', '--vlan_number'
-          @config[:filters][opt.slice(2, opt.length - 2).to_sym] = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}                           unless opt.to_s == '--storage_type'
-          @config[:filters][:network_storage_type]               = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}.map{|token| token.to_sym} if     opt.to_s == '--storage_type'
+        when '--datacenter', '--description', '--domain', '--fqdn', '--hardware_type', '--hostname', '--manufacturer', '--name', '--tag', '--type', '--vendor', '--vlan_number'
+          @config[:filters][opt.slice(2, opt.length - 2).to_sym] = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}
 
         when '--hardware'
           @config[:filters][:hardware_only] = true

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -8,6 +8,23 @@ require 'softlayer_api'
 module SoftLayer
   module Managers
     class Credentials
+      def self.get_user_credentials_lost_password_sec_questions(softlayer_client, lost_password_key)
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if ! lost_password_key || lost_password_key.empty?
+          raise ArgumentError, "A non nil or empty lost password reset key is required"
+        end
+
+        account_service = SoftLayer::Account.account_for_client(softlayer_client).service
+        current_user    = SoftLayer::UserCustomer.new(softlayer_client, account_service.object_mask(SoftLayer::UserCustomer.default_object_mask).getCurrentUser)
+
+        sec_questions = current_user.service.getUserFromLostPasswordRequest(lost_password_key)
+        sec_questions = current_user.service.getDefaultSecurityQuestions(lost_password_key) if sec_questions.empty?
+
+        return sec_questions
+      end
+
       def self.delete_software_credentials(softlayer_client, software_password_ids, options = {})
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
@@ -26,7 +43,7 @@ module SoftLayer
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-        if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
         end
 
@@ -86,7 +103,7 @@ module SoftLayer
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-        if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
         end
 
@@ -105,7 +122,7 @@ module SoftLayer
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-        if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
         end
 
@@ -128,7 +145,7 @@ module SoftLayer
                                                                                storage_credential['id'],
                                                                                storage_credential.username,
                                                                                storage_credential.password,
-                                                                               storage_credentials[:type].to_s,
+                                                                               storage_credentials[:type].to_s
                                                                               ]
           end
         end
@@ -140,11 +157,105 @@ module SoftLayer
         return true
       end
 
+      def self.list_user_credentials(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        users = get_users(softlayer_client, options).map do |user|
+          [ user['id'], [ user.last_name, ", ", user.first_name ].join, user.username, user.email, ! user['additionalEmails'].empty?, ! user['securityAnswers'].empty?, user.modified ]
+        end
+
+        users.unshift([ 'id', 'name', 'username', 'email', 'additional emails', 'security questions used', 'last modified' ])
+
+        pretty_print_table(users)
+
+        return true
+      end
+
+      def self.list_user_credentials_lost_password_sec_questions(softlayer_client, lost_password_key)
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if ! lost_password_key || lost_password_key.empty?
+          raise ArgumentError, "user action list-lost-password-sec-questions requires a non nil or empty lost password reset key"
+        end
+
+        sec_questions = get_user_credentials_lost_password_sec_questions(softlayer_client, lost_password_key)
+
+        sec_questions.map! { |sec_quest| [ sec_quest['id'], sec_quest['question'] ] }
+
+        sec_questions.unshift(['id', 'security question'])
+
+        pretty_print_table(sec_questions)
+
+        return true
+      end
+
+      def self.list_user_credentials_sec_questions(softlayer_client)
+        sec_questions = softlayer_client["SoftLayer_User_Security_Question"].getAllObjects
+
+        sec_questions.map! {|sec_question| [ sec_question['id'], sec_question['question'] ]}
+
+        sec_questions.unshift([ 'id', 'security question' ])
+
+        pretty_print_table(sec_questions)
+
+        return true
+      end
+
+      def self.list_user_credential_details(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        users = get_users(softlayer_client, options)
+
+        users.each do |user|
+          user_details = [ [ "name", "value" ] ]
+
+          sec_questions = user['securityAnswers'].map{|sec_question| [ sec_question['question']["question"], " (", sec_question['question']["id"], ")" ].join }
+
+          user_details.push([ 'id',                       user['id']                                                                                  ])
+          user_details.push([ 'first name',               user.first_name                                                                             ])
+          user_details.push([ 'last name',                user.last_name                                                                              ])
+          user_details.push([ 'email',                    user.email                                                                                  ])
+          user_details.push([ 'additional emails',        user.additional_emails.join(', ')                                                           ])
+          user_details.push([ 'password expires',         user.password_expires                                                                       ])
+          user_details.push([ 'last modified',            user.modified                                                                               ])
+          user_details.push([ 'username' ,                user.username                                                                               ])
+          user_details.push([ 'api key 1',                user.api_authentication_keys[0] ? user.api_authentication_keys[0]['authenticationKey'] : "" ])
+          user_details.push([ 'api key 2',                user.api_authentication_keys[1] ? user.api_authentication_keys[1]['authenticationKey'] : "" ])
+          user_details.push([ 'security question 1 (id)', sec_questions[0] || ""                                                                      ])
+          user_details.push([ 'security question 2 (id)', sec_questions[1] || ""                                                                      ])
+          user_details.push([ 'security question 3 (id)', sec_questions[2] || ""                                                                      ])
+
+          pretty_print_table(user_details)
+
+          puts if users.length > 1
+        end
+
+        return true
+      end
+
+      def self.send_user_credentials_lost_password_request(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if ! options[:filters] || options[:filters].empty? || ! options[:filters][:email] || ! options[:filters][:username] || options[:filters][:username].empty?
+          raise ArgumentError, "user action lost-password-request requires filter options email and username"
+        end
+
+        softlayer_client["SoftLayer_User_Customer"].lostPassword(options[:filters][:username], options[:filters][:email])
+      end
+
       def self.set_network_message_delivery_credentials(softlayer_client, password, options = {})
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-        if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+        if ! password || password.empty?
+          raise ArgumentError, "network_mesage_delivery action set requires a non nil or empty password"
+        end
+
+        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
         end
 
@@ -168,7 +279,11 @@ module SoftLayer
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-        if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+        if ! password || password.empty?
+          raise ArgumentError, "software action set requires a non nil or empty password"
+        end
+
+        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
         end
 
@@ -191,7 +306,11 @@ module SoftLayer
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-        if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+        if ! password || password.empty?
+          raise ArgumentError, "software action set requires a non nil or empty password"
+        end
+
+        if (! options[:filters] || options[:filtesr].empty?) && (! options[:yes_prompt])
           return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
         end
 
@@ -200,7 +319,7 @@ module SoftLayer
         end
 
         network_storage_data = get_storage(softlayer_client, options)
-        user_filter          = (options[:filter] && options[:filter][:username]) ? options[:filter][:username] : []
+        user_filter          = (options[:filters] && options[:filters][:username]) ? options[:filters][:username] : []
 
         network_storage_data.each do |network_storage|
           network_storage.password=(password) if user_filter.empty? || user_filter.include?(network_storage.username)
@@ -214,23 +333,120 @@ module SoftLayer
         return true
       end
 
+      def self.set_user_credentials(softlayer_client, password, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if ! password || password.empty?
+          raise ArgumentError, "user action set requires a non nil or empty password"
+        end
+
+        if ! options[:filters] || options[:filters].empty? || ! options[:filters][:password_type] || ! options[:filters][:username] || options[:filters][:username].empty?
+          raise ArgumentError, "user action set requires filter options password_type and username"
+        end
+
+        if ! options[:yes_prompt]
+          return false unless yes_prompt("You are setting user #{options[:filters][:password_type]} credentials, this cannot be undone, continue?")
+        end
+
+        user = get_users(softlayer_client, options).first
+
+        if ! user
+          raise Exception, "user action set failed to find username #{options[:filters][:username].first}"
+        end
+
+        case options[:filters][:password_type]
+        when :forum
+          user.service.updateForumPassword(password)
+        when :portal
+          user.service.updatePassword(password)
+        when :vpn
+          user.service.updateVpnPassword(password)
+        end
+
+        return true
+      end
+
+      def self.set_user_credentials_lost_password(softlayer_client, lost_password_key, password, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if ! lost_password_key || lost_password_key.empty?
+          raise ArgumentError, "user action set-lost-password requires a non nil or empty lost password reset key"
+        end
+
+        if ! password || password.empty?
+          raise ArgumentError, "user action set-lost-password requires a non nil or empty password"
+        end
+
+        if ! options[:filters] || options[:filters].empty? || ! options[:filters][:security_question_ids] ||
+             options[:filters][:security_question_ids].empty? || ! [ 1, 3 ].include?(options[:filters][:security_question_ids].length)
+          raise ArgumentError, "user action set-lost-password requires three security question id's that correspond to each answer"
+        end
+
+        if ! options[:filters] || options[:filters].empty? || ! options[:filters][:answer] ||
+             options[:filters][:answer].empty? || ! [ 1, 3 ].include?(options[:filters][:answer].length)
+          raise ArgumentError, "user action set-lost-password requires three security question answers's that correspond to each security question id"
+        end
+
+        if options[:filters][:answer].length != options[:filters][:security_question_ids].length
+          raise ArgumentError, "user action set-lost-password requires equal number security question answers and security question ids"
+        end
+
+        sec_quest_answers = (0..(options[:filters][:answer].length - 1)).to_a.map do |sec_quest_index|
+          {
+            'answer'     => options[:filters][:answer][sec_quest_index],
+            'questionId' => options[:filters][:security_question_ids][sec_quest_index]
+          }
+        end
+
+        account_service = SoftLayer::Account.account_for_client(softlayer_client).service
+        current_user    = SoftLayer::UserCustomer.new(softlayer_client, account_service.object_mask(SoftLayer::UserCustomer.default_object_mask).getCurrentUser)
+
+        current_user.service.setPasswordFromLostPasswordRequest(lost_password_key, password, sec_quest_answers)
+      end
+
+      def self.set_user_credentials_sec_answers(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if ! options[:filters] || options[:filters].empty? || ! options[:filters][:security_question_ids] ||
+            options[:filters][:security_question_ids].empty? || options[:filters][:security_question_ids].length != 3
+          raise ArgumentError, "user action set-sec-answers requires three security question id's that correspond to each answer"
+        end
+
+        if ! options[:filters] || options[:filters].empty? || ! options[:filters][:answer] ||
+            options[:filters][:answer].empty? || options[:filters][:answer].length != 3
+          raise ArgumentError, "user action set-sec-answers requires three security question answers's that correspond to each security question id"
+        end
+
+        if options[:filters][:answer].length != options[:filters][:security_question_ids].length
+          raise ArgumentError, "user action set-sec-answers requires equal number security question answers and security question ids"
+        end
+
+        account_service = SoftLayer::Account.account_for_client(softlayer_client).service
+        current_user    = SoftLayer::UserCustomer.new(softlayer_client, account_service.object_mask(SoftLayer::UserCustomer.default_object_mask).getCurrentUser)
+
+        current_user.service.updateSecurityAnswers(options[:filters][:security_question_ids].map { |sec_id| {'id' => sec_id } }, options[:filters][:answer])
+      end
+
       private
 
       def self.add_software_credentials(softlayer_client, password, options = {})
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
-        raise "Expected a list of usernames to add software credentials for as part of filters" if ! options[:filter] || ! options[:filter][:username] || options[:filter][:username].empty?
+        raise "Expected a list of usernames to add software credentials for as part of filters" if ! options[:filters] || ! options[:filters][:username] || options[:filters][:username].empty?
 
         hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
 
         add_hardware_passwords       = true
         add_virtual_server_passwords = true
 
-        add_hardware_passwords       = false if options[:filter] && options[:filter][:virtual_servers_only]
-        add_virtual_server_passwords = false if options[:filter] && options[:filter][:hardware_only]
+        add_hardware_passwords       = false if options[:filters] && options[:filters][:virtual_servers_only]
+        add_virtual_server_passwords = false if options[:filters] && options[:filters][:hardware_only]
 
-        if add_hardware_passwords && (options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?)
-          hardware_types             = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
+        if add_hardware_passwords && (options[:filters][:hardware_type] && ! options[:filters][:hardware_type].empty?)
+          hardware_types             = options[:filters][:hardware_type].map { |hardware_type| hardware_type.to_sym }
         end
 
         object_filters               = software_password_filters(:add, options)
@@ -258,7 +474,7 @@ module SoftLayer
         end
 
         software_passwords_template = software.map do |sw|
-          options[:filter][:username].collect do |username|
+          options[:filters][:username].collect do |username|
             { 'softwareId' => sw['id'], 'password' => password.to_s, 'username' => username } if sw['passwords'] && ! sw['passwords'].map{ |pw| pw['username'] }.include?(username)
           end
         end
@@ -276,11 +492,11 @@ module SoftLayer
         list_hardware_passwords       = true
         list_virtual_server_passwords = true
 
-        list_hardware_passwords       = false if options[:filter] && options[:filter][:virtual_servers_only]
-        list_virtual_server_passwords = false if options[:filter] && options[:filter][:hardware_only]
+        list_hardware_passwords       = false if options[:filters] && options[:filters][:virtual_servers_only]
+        list_virtual_server_passwords = false if options[:filters] && options[:filters][:hardware_only]
 
-        if list_hardware_passwords && (options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?)
-          hardware_types              = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
+        if list_hardware_passwords && (options[:filters][:hardware_type] && ! options[:filters][:hardware_type].empty?)
+          hardware_types              = options[:filters][:hardware_type].map { |hardware_type| hardware_type.to_sym }
         end
 
         object_filters                = software_password_filters(:list, options)
@@ -314,14 +530,14 @@ module SoftLayer
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-        if options[:filter] && options[:filter][:network_storage_type] && ! options[:filter][:network_storage_type].empty?
-          storage_types                  = options[:filter][:network_storage_type]
+        if options[:filters] && options[:filters][:network_storage_type] && ! options[:filters][:network_storage_type].empty?
+          storage_types                  = options[:filters][:network_storage_type]
         else
           storage_types                  = [ :evault, :hub, :iscsi, :lockbox, :nas, :network_storage ]
         end
 
-        list_hardware_storage_credentials       = (options[:filter] && options[:filter][:virtual_servers_only]) ? false : true
-        list_virtual_server_storage_credentials = (options[:filter] && options[:filter][:hardware_only])        ? false : true
+        list_hardware_storage_credentials       = (options[:filters] && options[:filters][:virtual_servers_only]) ? false : true
+        list_virtual_server_storage_credentials = (options[:filters] && options[:filters][:hardware_only])        ? false : true
 
         object_filters                          = storage_filters(options)
 
@@ -349,10 +565,10 @@ module SoftLayer
 
         network_storage_data = network_storage_data.values
         
-        if options[:filter] && options[:filter][:username] && ! options[:filter][:username].empty?
-            network_storage_data.delete_if do |network_storage|
-              ! (options[:filter][:username] - [ network_storage.username, network_storage.credentials.map{|cred| cred.username} ].flatten).empty?
-            end
+        if options[:filters] && options[:filters][:username] && ! options[:filters][:username].empty?
+          network_storage_data.delete_if do |network_storage|
+            ! (options[:filters][:username] - [ network_storage.username, network_storage.credentials.map{|cred| cred.username} ].flatten).empty?
+          end
         end
 
         return network_storage_data
@@ -366,7 +582,7 @@ module SoftLayer
 
         storage_credentials = {}
 
-        user_filter = (options[:filter] && options[:filter][:username]) ? options[:filter][:username] : []
+        user_filter = (options[:filters] && options[:filters][:username]) ? options[:filters][:username] : []
 
         network_storage_data.each do |network_storage|
           storage_credentials[network_storage.service_resource.private_ip] ||= {
@@ -395,6 +611,19 @@ module SoftLayer
         end
 
         return storage_credentials
+      end
+
+      def self.get_users(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        account_service = SoftLayer::Account.account_for_client(softlayer_client).service
+        account_service = account_service.object_filter(user_filters(options)) unless user_filters(options).empty?
+        account_service = account_service.object_mask(user_mask)
+
+        users = account_service.getUsers.collect { |user| SoftLayer::UserCustomer.new(softlayer_client, user) unless user.empty? }.compact
+
+        return users
       end
 
       def self.object_filter_criteria_contains(object_filter, filter_path, contains_data)
@@ -454,10 +683,10 @@ module SoftLayer
 
         net_msg_deliv_object_filter = SoftLayer::ObjectFilter.new()
 
-        if options[:filter]
+        if options[:filters]
           option_to_filter_path.each do |option, filter_path|
-            if options[:filter][option] && ! options[:filter][option].empty?
-              object_filter_criteria_contains(net_msg_deliv_object_filter, filter_path, options[:filter][option])
+            if options[:filters][option] && ! options[:filters][option].empty?
+              object_filter_criteria_contains(net_msg_deliv_object_filter, filter_path, options[:filters][option])
             end
           end
         end
@@ -512,34 +741,34 @@ module SoftLayer
           }
         }
 
-        if options[:filter]
-          list_hardware_passwords       = false if options[:filter][:virtual_servers_only]
-          list_virtual_server_passwords = false if options[:filter][:hardware_only]
+        if options[:filters]
+          list_hardware_passwords       = false if options[:filters][:virtual_servers_only]
+          list_virtual_server_passwords = false if options[:filters][:hardware_only]
 
           option_to_filter_path[:software].each do |option, filter_path|
-            if options[:filter][option] && ! options[:filter][option].empty?
+            if options[:filters][option] && ! options[:filters][option].empty?
               next if option == :username && filter_type == :add
 
-              object_filter_criteria_contains(software_object_filter, filter_path, options[:filter][option])
+              object_filter_criteria_contains(software_object_filter, filter_path, options[:filters][option])
             end
           end
 
           option_to_filter_path[:software_password].each do |option, filter_path|
-            if options[:filter][option] && ! options[:filter][option].empty?
+            if options[:filters][option] && ! options[:filters][option].empty?
 
-              object_filter_criteria_contains(software_password_object_filter, filter_path, options[:filter][option])
+              object_filter_criteria_contains(software_password_object_filter, filter_path, options[:filters][option])
             end
           end
 
           if list_hardware_passwords
-            if options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?
-              hardware_types = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
+            if options[:filters][:hardware_type] && ! options[:filters][:hardware_type].empty?
+              hardware_types = options[:filters][:hardware_type].map { |hardware_type| hardware_type.to_sym }
             end
 
             hardware_types.each do |hardware_type|
               option_to_filter_path[:hardware].each do |option, filter_path|
-                if options[:filter][option] && ! options[:filter][option].empty?
-                  object_filter_criteria_contains(hardware_object_filter[hardware_type], filter_path.call(hardware_type),  options[:filter][option])
+                if options[:filters][option] && ! options[:filters][option].empty?
+                  object_filter_criteria_contains(hardware_object_filter[hardware_type], filter_path.call(hardware_type),  options[:filters][option])
                 end
               end
             end
@@ -547,8 +776,8 @@ module SoftLayer
 
           if list_virtual_server_passwords
             option_to_filter_path[:virtual_server].each do |option, filter_path|
-              if options[:filter][option] && ! options[:filter][option].empty?
-                object_filter_criteria_contains(virtual_server_object_filter, filter_path, options[:filter][option])
+              if options[:filters][option] && ! options[:filters][option].empty?
+                object_filter_criteria_contains(virtual_server_object_filter, filter_path, options[:filters][option])
               end
             end
           end
@@ -574,8 +803,8 @@ module SoftLayer
           :virtual_server  => "virtualGuest"
         }
 
-        list_hardware_storage_credentials       = (options[:filter] && options[:filter][:virtual_servers_only]) ? false : true
-        list_virtual_server_storage_credentials = (options[:filter] && options[:filter][:hardware_only])        ? false : true
+        list_hardware_storage_credentials       = (options[:filters] && options[:filters][:virtual_servers_only]) ? false : true
+        list_virtual_server_storage_credentials = (options[:filters] && options[:filters][:hardware_only])        ? false : true
 
         option_to_filter_path = {
           :datacenter => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.datacenter.name' ].join                  },
@@ -590,8 +819,8 @@ module SoftLayer
           :virtual_server => {}
         }
 
-        if options[:filter] && options[:filter][:network_storage_type] && ! options[:filter][:network_storage_type].empty?
-          storage_types                  = options[:filter][:network_storage_type]
+        if options[:filters] && options[:filters][:network_storage_type] && ! options[:filters][:network_storage_type].empty?
+          storage_types                  = options[:filters][:network_storage_type]
         else
           storage_types                  = filter_label.keys.select{|label| filter_label[label].end_with?("Storage") }
         end
@@ -604,32 +833,48 @@ module SoftLayer
           storage_types.each {|storage_type| storage_object_filter[:virtual_server][storage_type] = SoftLayer::ObjectFilter.new() }
         end
 
-        if options[:filter]
+        if options[:filters]
           [ :datacenter, :domain, :hostname, :tags ].each do |option|
             filter_path = option_to_filter_path[option]
-            if options[:filter][option] && ! options[:filter][option].empty?
+            if options[:filters][option] && ! options[:filters][option].empty?
               if list_hardware_storage_credentials
-                storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:hardware][storage_type], filter_path.call(storage_type, :hardware), options[:filter][option]) }
+                storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:hardware][storage_type], filter_path.call(storage_type, :hardware), options[:filters][option]) }
               end
 
               if list_virtual_server_storage_credentials
-                storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:virtual_server][storage_type], filter_path.call(storage_type, :virtual_server), options[:filter][option]) }
+                storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:virtual_server][storage_type], filter_path.call(storage_type, :virtual_server), options[:filters][option]) }
               end
             end
           end
 
-          if options[:filter][:service] && ! options[:filter][:service].empty?
+          if options[:filters][:service] && ! options[:filters][:service].empty?
             if list_hardware_storage_credentials
-              storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:hardware][storage_type], options_to_filter_path[:service].call(storage_type), options[:filter][:service]) }
+              storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:hardware][storage_type], options_to_filter_path[:service].call(storage_type), options[:filters][:service]) }
             end
 
             if list_virtual_server_storage_credentials
-              storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:virtual_server][storage_type], options_to_filter_path[:service].call(storage_type), options[:filter][:service]) }
+              storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:virtual_server][storage_type], options_to_filter_path[:service].call(storage_type), options[:filters][:service]) }
             end
           end
         end
         
         return storage_object_filter
+      end
+
+      def self.user_filters(options = {})
+        options_to_filter_path = {
+          :username => "users.username"
+        }
+
+        user_object_filter = SoftLayer::ObjectFilter.new()
+
+        if options[:filters]
+          if options[:filters][:username] && ! options[:filters][:username].empty?
+            object_filter_criteria_contains(user_object_filter, options_to_filter_path[:username], options[:filters][:username])
+          end
+        end
+
+        return user_object_filter
       end
 
       def self.software_password_mask(mask_type)
@@ -678,6 +923,28 @@ module SoftLayer
         }.to_sl_object_mask
       end
 
+      def self.user_mask()
+        {
+          "mask(SoftLayer_User_Customer)" => [
+                                              'additionalEmails.email',
+                                              'alternatePhone',
+                                              'apiAuthenticationKeys.authenticationKey',
+                                              'createDate',
+                                              'displayName',
+                                              'email',
+                                              'firstName',
+                                              'id',
+                                              'lastName',
+                                              'modifyDate',
+                                              'officePhone',
+                                              'passwordExpireDate',
+                                              'securityAnswers[answer,id,question,questionId,userId]',
+                                              'statusDate',
+                                              'username'
+                                             ]
+        }.to_sl_object_mask
+      end
+
       def self.yes_prompt(prompt_message)
         while true do
           $stderr.print prompt_message.to_s + " (Y/N): "
@@ -700,6 +967,7 @@ class VagrantSoftLayerCredentials
   def initialize()
     @cli_opts = [
                  [ '--add',             '-a', GetoptLong::NO_ARGUMENT       ],
+                 [ '--answer',          '-A', GetoptLong::NO_ARGUMENT       ],
                  [ '--datacenter',      '-d', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--description',           GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--domain',          '-D', GetoptLong::REQUIRED_ARGUMENT ],
@@ -723,11 +991,13 @@ class VagrantSoftLayerCredentials
                 ]
     @config   = {
       :action            => nil,
-      :action_args       => [],
+      :answer            => [],
+      :answer_flag       => false,
       :add_user_password => false,
       :category          => nil,
       :filters           => {},
       :help              => false,
+      :lost_password_key => nil,
       :password          => nil,
       :password_flag     => false,
       :sl_credentials    => {
@@ -743,10 +1013,19 @@ class VagrantSoftLayerCredentials
     @help = {
       :network_message_delivery => {},
       :software                 => {},
-      :storage                  => {}
+      :storage                  => {},
+      :user                     => {}
     }
+    @softlayer_client = nil
 
     @help[:std_opts] = <<-HELP_STD_OPTS
+WARNING:
+ This tool is intended to simplify bulk changes to SoftLayer credentials. If you do not
+ specify filters for 'set' actions the action will be taken on all available resources for
+ that particular category. Be sure to test your filters using the 'list' option and provide as
+ many filters as posible to narrow your selection. If you do not intend to do bulk updates,
+ please take a look at the functionality of the SoftLayer Python cli tool 'sl' instead.
+
 Standard Options:
 
 --help|-h:
@@ -769,23 +1048,37 @@ HELP_STD_OPTS
     @help[:help]     = <<-HELP_EOM
 Usage: #{File.basename($0)} <category> <action> [<args>...] [<options>...]
        #{File.basename($0)} <category> <action> [-h | --help]
-       #{File.basename($0)} [-h | --help ]
+       #{File.basename($0)} [-h | --help]
 
 The following credential management categories and associated actions are available:
 
 network_message_delivery:
-  list          List credential username/password(s) for network message delivery services.
-  set           Set credential password for username(s) related to network message delivery services.
+  list                              List credential username/password(s) for network message delivery services.
+  set                               Set credential password for username(s) related to network message
+                                    delivery services.
 
 software:
-  delete        Delete credential username/password(s) for installed software.
-  list          List credential username/password(s) for installed software.
-  list-details  List credential details for a specific username/password instance related to installed software.
-  set           Set credential password for username(s) related to installed software.
+  delete                            Delete credential username/password(s) for installed software.
+  list                              List credential username/password(s) for installed software.
+  list-details                      List credential details for a specific username/password instance related
+                                    to installed software.
+  set                               Set credential password for username(s) related to installed software.
 
 storage:
-  list          List credential username/password(s) for network storage services.
-  set           Set credential password for username(s) related to network storage services.
+  list                              List credential username/password(s) for network storage services.
+  set                               Set credential password for username(s) related to network
+                                    storage services.
+
+user:
+  list                              List credential usernames for SoftLayer accounts.
+  list-details                      List credential username details for SoftLayer accounts.
+  list-lost-password-sec-questions  List the questions that need to be answered when setting lost
+                                    password for a SoftLayer account.
+  list-sec-questions                List available security questions for SoftLayer accounts. 
+  lost-password                     Send lost password reset request for key to reset a SoftLayer account.
+  set                               Set credential password for username of a SoftLayer account.
+  set-lost-password                 Set lost password using reset key sent in email for a SoftLayer account.
+  set-sec-answers                   Set security question answers for SoftLayer account.
 
 #{@help[:std_opts]}
 HELP_EOM
@@ -978,7 +1271,7 @@ HELP_STOR_LIST
     @help[:storage][:set]     = <<-HELP_STOR_SET
 Usage: #{File.basename($0)} storage set [options] [<password>]
 
-List Credential Options:
+Set Credential Options:
 
 --password|-p:
     Prompt for password from STDIN instead of expecting password as an argument.
@@ -997,10 +1290,103 @@ List Credential Options:
 #{@help[:storage_filters]}
 #{@help[:std_opts]}
 HELP_STOR_SET
+
+    @help[:user][:list]       = <<-HELP_USER_LIST
+Usage: #{File.basename($0)} user list [options]
+
+List Credential Options:
+
+--username|-u <USERNAME>,...:
+    List the user credentials of accounts for these username(s) only.
+
+#{@help[:std_opts]}
+HELP_USER_LIST
+
+    @help[:user][:"list-details"]  = <<-HELP_USER_LIST_DETAILS
+Usage: #{File.basename($0)} user list-details [options] <username>...
+
+#{@help[:std_opts]}
+HELP_USER_LIST_DETAILS
+
+    @help[:user][:"list-lost-password-sec-questions"] = <<-HELP_LIST_LOST_PW_SEC_QUEST
+Usage: #{File.basename($0)} user list-lost-password-sec-questions [options] <lost_password_key>
+
+#{@help[:std_opts]}
+HELP_LIST_LOST_PW_SEC_QUEST
+
+    @help[:user][:"list-sec-questions"] = <<-HELP_USER_LIST_SEC_QUEST
+Usage: #{File.basename($0)} user list-sec-questions [options]
+
+#{@help[:std_opts]}
+HELP_USER_LIST_SEC_QUEST
+
+    @help[:user][:"lost-password"] = <<-HELP_USER_LOST_PW
+Usage: #{File.basename($0)} user lost-password [options] <username> <email>
+
+#{@help[:std_opts]}
+HELP_USER_LOST_PW
+
+    @help[:user][:set]        = <<-HELP_USER_SET
+Usage: #{File.basename($0)} user set [options] <forum|portal|vpn> username [<password> <confirm password>]
+
+Set Credential Options:
+
+--password|-p:
+    Prompt for password from STDIN instead of expecting password as an argument.
+    If not specified, it is expected that password is provided as an argument to
+    the action. If both the argument and this option are provided, the argument
+    takes precedence and the password will not be read.
+
+#{@help[:std_opts]}
+HELP_USER_SET
+
+    @help[:user][:"set-lost-password"] = <<-HELP_USER_SET_LOST_PW
+Usage: #{File.basename($0)} user set-lost-password [options] <lost_password_key> <sec_quest_id> <sec_quest_id> <sec_quest_id>
+                                                            [<sec_quest_ans> <sec_quest_ans> <sec_quest_ans>] [<new_password> <confirm_password>]
+       #{File.basename($0)} user set-lost-password [options] <lost_password_key> <sec_quest_id> [<sec_quest_ans>]
+                                                            [<new_password> <confirm_password>]
+
+Note: If you have not yet set your account security questions, there will be a single default security question asked instead of the normal 3
+      that would be asked for if you do have security questions set.
+
+Set Credential Options:
+
+--answer|-A:
+    Prompt for answers from STDIN instead of expecting answers as an argument.
+    If not specified, it is expected that answers are provided as an argument to
+    the action. If both the argument and this option are provided, the argument
+    takes precedence and the answers will not be read.
+
+--password|-p:
+    Prompt for password from STDIN instead of expecting password as an argument.
+    If not specified, it is expected that password is provided as an argument to
+    the action. If both the argument and this option are provided, the argument
+    takes precedence and the password will not be read.
+
+#{@help[:std_opts]}
+HELP_USER_SET_LOST_PW
+
+    @help[:user][:"set-sec-answers"] = <<-HELP_USER_SET_SEC_ANS
+Usage: #{File.basename($0)} user set-sec-answers [options] <sec_quest_id> <sec_quest_id> <sec_quest_id>
+                                                          [<sec_quest_ans> <sec_quest_ans> <sec_quest_ans>]
+
+Set Credential Options:
+
+--answer|-A:
+    Prompt for answers from STDIN instead of expecting an answeras an argument.
+    If not specified, it is expected that answers are provided as an argument to
+    the action. If both the argument and this option are provided, the argument
+    takes precedence and the answers will not be read.
+
+#{@help[:std_opts]}
+HELP_USER_SET_SEC_ANS
   end
 
   def run()
     proc_cli_options
+
+    @softlayer_client = SoftLayer::Client.new(@config[:sl_credentials])
+
     proc_cli_args
 
     if @config[:help]
@@ -1013,8 +1399,6 @@ HELP_STOR_SET
       end
     end
 
-    softlayer_client = SoftLayer::Client.new(@config[:sl_credentials])
-
     begin
       case @config[:category]
       when :network_message_delivery
@@ -1023,48 +1407,48 @@ HELP_STOR_SET
           list_filter            = @config[:filters]
           list_filter[:username] = @config[:username] unless @config[:username].empty?
 
-          exit 0 unless SoftLayer::Managers::Credentials.list_network_message_delivery_credentials(softlayer_client,
-                                                                                                   :filter     => list_filter,
+          exit 1 unless SoftLayer::Managers::Credentials.list_network_message_delivery_credentials(@softlayer_client,
+                                                                                                   :filters    => list_filter,
                                                                                                    :yes_prompt => @config[:yes_prompt])
 
         when :set
           set_filter            = @config[:filters]
           set_filter[:username] = @config[:username] unless @config[:username].empty?
 
-          exit 0 unless SoftLayer::Managers::Credentials.set_network_message_delivery_credentials(softlayer_client,
+          exit 1 unless SoftLayer::Managers::Credentials.set_network_message_delivery_credentials(@softlayer_client,
                                                                                                   @config[:password],
-                                                                                                  :filter     => @config[:filters],
+                                                                                                  :filters    => @config[:filters],
                                                                                                   :yes_prompt => @config[:yes_prompt])
 
         end
       when :software
         case @config[:action]
         when :delete
-          exit 0 unless SoftLayer::Managers::Credentials.delete_software_credentials(softlayer_client,
-                                                                                     @config[:action_args],
+          exit 1 unless SoftLayer::Managers::Credentials.delete_software_credentials(@softlayer_client,
+                                                                                     @config[:filters][:credentials],
                                                                                      :yes_prompt => @config[:yes_prompt])
 
         when :list
           list_filter            = @config[:filters]
           list_filter[:username] = @config[:username] unless @config[:username].empty?
 
-          exit 0 unless SoftLayer::Managers::Credentials.list_software_credentials(softlayer_client,
-                                                                                   :filter     => list_filter,
+          exit 1 unless SoftLayer::Managers::Credentials.list_software_credentials(@softlayer_client,
+                                                                                   :filters    => list_filter,
                                                                                    :yes_prompt => @config[:yes_prompt])
 
         when :"list-details"
-          SoftLayer::Managers::Credentials.list_software_credential_details(softlayer_client, @config[:action_args])
+          exit 1 unless SoftLayer::Managers::Credentials.list_software_credential_details(@softlayer_client, @config[:filters][:credentials])
 
         when :set
           set_filter            = @config[:filters]
           set_filter[:username] = @config[:username] unless @config[:username].empty?
 
-          exit 0 unless SoftLayer::Managers::Credentials.set_software_credentials(softlayer_client,
+          exit 1 unless SoftLayer::Managers::Credentials.set_software_credentials(@softlayer_client,
                                                                                   @config[:password],
                                                                                   :add_user_password => @config[:add_user_password],
-                                                                                  :filter            => @config[:filters],
+                                                                                  :filters           => @config[:filters],
                                                                                   :yes_prompt        => @config[:yes_prompt])
-            
+
         end
 
       when :storage
@@ -1073,18 +1457,75 @@ HELP_STOR_SET
           list_filter            = @config[:filters]
           list_filter[:username] = @config[:username] unless @config[:username].empty?
 
-          exit 0 unless SoftLayer::Managers::Credentials.list_storage_credentials(softlayer_client,
-                                                                                  :filter     => list_filter,
+          exit 1 unless SoftLayer::Managers::Credentials.list_storage_credentials(@softlayer_client,
+                                                                                  :filters    => list_filter,
                                                                                   :yes_prompt => @config[:yes_prompt])
 
         when :set
           set_filter            = @config[:filters]
           set_filter[:username] = @config[:username] unless @config[:username].empty?
 
-          exit 0 unless SoftLayer::Managers::Credentials.set_storage_credentials(softlayer_client,
+          exit 1 unless SoftLayer::Managers::Credentials.set_storage_credentials(@softlayer_client,
                                                                                  @config[:password],
-                                                                                 :filter            => @config[:filters],
-                                                                                 :yes_prompt        => @config[:yes_prompt])
+                                                                                 :filters    => @config[:filters],
+                                                                                 :yes_prompt => @config[:yes_prompt])
+
+        end
+
+      when :user
+        case @config[:action]
+        when :list
+          list_filter            = @config[:filters]
+          list_filter[:username] = @config[:username] unless @config[:username].empty?
+
+          exit 1 unless SoftLayer::Managers::Credentials.list_user_credentials(@softlayer_client,
+                                                                               :filters => list_filter)
+
+        when :"list-details"
+          list_filter            = @config[:filters]
+          list_filter[:username] = @config[:username] unless @config[:username].empty?
+
+          exit 1 unless SoftLayer::Managers::Credentials.list_user_credential_details(@softlayer_client,
+                                                                                      :filters => list_filter)
+
+        when :"list-lost-password-sec-questions"
+          exit 1 unless SoftLayer::Managers::Credentials.list_user_credentials_lost_password_sec_questions(@softlayer_client,
+                                                                                                           @config[:lost_password_key])
+
+        when :"list-sec-questions"
+          exit 1 unless SoftLayer::Managers::Credentials.list_user_credentials_sec_questions(@softlayer_client)
+
+        when :"lost-password"
+          set_filter            = @config[:filters]
+          set_filter[:username] = @config[:username]
+
+          exit 1 unless SoftLayer::Managers::Credentials.send_user_credentials_lost_password_request(@softlayer_client,
+                                                                                                     :filters => @config[:filters])
+
+        when :set
+          set_filter            = @config[:filters]
+          set_filter[:username] = @config[:username]
+
+          exit 1 unless SoftLayer::Managers::Credentials.set_user_credentials(@softlayer_client,
+                                                                              @config[:password],
+                                                                              :filters    => @config[:filters],
+                                                                              :yes_prompt => @config[:yes_prompt])
+
+        when :"set-lost-password"
+          set_filter            = @config[:filters]
+          set_filter[:answer]   = @config[:answer]
+
+          exit 1 unless SoftLayer::Managers::Credentials.set_user_credentials_lost_password(@softlayer_client,
+                                                                                            @config[:lost_password_key],
+                                                                                            @config[:password],
+                                                                                            :filters => @config[:filters])
+
+        when :"set-sec-answers"
+          set_filter            = @config[:filters]
+          set_filter[:answer]   = @config[:answer]
+
+          exit 1 unless SoftLayer::Managers::Credentials.set_user_credentials_sec_answers(@softlayer_client,
+                                                                                          :filters => @config[:filters])
 
         end
 
@@ -1097,8 +1538,13 @@ HELP_STOR_SET
 
   private
 
-  def password_prompt()
-    $stderr.print "Enter credential password: "
+  def answer_prompt(question_number)
+    $stderr.print "Answer question #{question_number}: "
+    return $stdin.readline().chomp!
+  end
+
+  def password_prompt(confirm = false)
+    $stderr.print "#{confirm ? "Confirm" : "Enter"} credential password: "
     return $stdin.readline().chomp!
   end
 
@@ -1108,137 +1554,266 @@ HELP_STOR_SET
       exit 2
     end
 
-    case ARGV[0]
-    when "network_message_delivery"
-      @config[:category] = :network_message_delivery
+    category_actions = {
+      :network_message_delivery => {
+        :actions       => [ :list, :set ],
+        :accept_params => [ :set ]
+      },
+      :software                 => {
+        :actions       => [ :delete, :list, :"list-details", :set ],
+        :accept_params => [ :delete, :"list-details", :set ]
+      },
+      :storage                  => {
+        :actions       => [ :list, :set ],
+        :accept_params => [ :set ]
+      },
+      :user                     => {
+        :actions       => [ :list, :"list-details", :"list-lost-password-sec-questions", :"list-sec-questions", :"lost-password", :set, :"set-lost-password", :"set-sec-answers" ],
+        :accept_params => [ :"list-details", :"list-lost-password-sec-questions", :"lost-password", :set, :"set-lost-password", :"set-sec-answers" ]
+      }
+    }
+
+    if ARGV[0]
+      if ! category_actions.keys.include?(ARGV[0].to_sym)
+        unless @config[:help]
+          $stderr.puts "ERROR: Invalid credential category provided to perform action on"
+          exit 2
+        end
+      end
 
       if ARGV[1] == nil
         $stderr.puts "ERROR: No action provided for credential category #{ARGV[0]}"
         exit 2
       end
 
-      case ARGV[1]
-      when "list", "set"
-        @config[:action] = ARGV[1].to_sym
-
-      else
+      if ! category_actions[ARGV[0].to_sym][:actions].include?(ARGV[1].to_sym)
         $stderr.puts "ERROR: Invalid action for credential category #{ARGV[0]}: #{ARGV[1]}"
         exit 2
-
       end
 
-      case ARGV[1]
-      when "set"
-        if ARGV.length != 3 && ! @config[:password_flag]
-          $stderr.puts "ERROR: network_message_delivery action set requires a password be supplied either as an argument or read from STDIN using --password or -p option"
-          exit 2
-        end
-        
-        if ARGV.length == 3
-          @config[:password] = ARGV[2].to_s
-        elsif @config[:password_flag]
-          @config[:password] = password_prompt
-        end
-
-      else
-        if ARGV.length >= 3
-          $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} does not accept any arguments"
-          exit 2
-        end
-
-      end
-
-    when "software"
-      @config[:category] = :software
-
-      if ARGV[1] == nil
-        $stderr.puts "ERROR: No action provided for credential category #{ARGV[0]}"
+      if ! category_actions[ARGV[0].to_sym][:accept_params].include?(ARGV[1].to_sym) && ARGV.length >= 3
+        $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} does not accept any arguments"
         exit 2
       end
 
-      case ARGV[1]
-      when "delete", "list", "list-details", "set"
-        @config[:action] = ARGV[1].to_sym
+      @config[:category] = ARGV[0].to_sym if ARGV[0]
+      @config[:action]   = ARGV[1].to_sym if ARGV[1]
 
-      else
-        $stderr.puts "ERROR: Invalid action for credential category #{ARGV[0]}: #{ARGV[1]}"
-        exit 2
+      if ! @config[:help]
+        case ARGV[0]
+        when "network_message_delivery"
+          if ARGV[1] == "set"
+            if (ARGV.length == 2 && ! @config[:password_flag]) || ! [ 2, 3 ].include?(ARGV.length)
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
+              exit 2
+            end
 
+            if ARGV.length == 3
+              @config[:password] = ARGV[2].to_s
+            elsif @config[:password_flag]
+              @config[:password] = password_prompt
+            end
+          end
+
+        when "software"
+          case ARGV[1]
+          when "delete", "list-details"
+            if ARGV.length < 3
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires one or more software credential ID"
+              exit 2
+            end
+
+            @config[:filters][:credentials] = ARGV.slice(2, ARGV.length - 2)
+
+          when "set"
+            if (ARGV.length == 2 && ! @config[:password_flag]) || ! [ 2, 3 ].include?(ARGV.length)
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
+              exit 2
+            end
+
+            if ARGV.length == 3
+              @config[:password] = ARGV[2].to_s
+            elsif @config[:password_flag]
+              @config[:password] = password_prompt
+            end
+
+          end
+
+        when "storage"
+          if ARGV[1] == "set"
+            if (ARGV.length == 2 && ! @config[:password_flag]) || ! [ 2, 3 ].include?(ARGV.length)
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
+              exit 2
+            end
+
+            if ARGV.length == 3
+              @config[:password] = ARGV[2].to_s
+            elsif @config[:password_flag]
+              @config[:password] = password_prompt
+            end
+          end
+
+        when "user"
+          case ARGV[1]
+          when "list-details"
+            if ARGV.length < 3
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires one or more user usernames"
+              exit 2
+            end
+
+            @config[:username] = ARGV.slice(2, ARGV.length - 2)
+
+          when "list-lost-password-sec-questions"
+            if ARGV.length != 3
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a lost password reset key"
+              exit 2
+            end
+
+            @config[:lost_password_key] = ARGV[2]
+
+          when "lost-password"
+            if ARGV.length != 4
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a username to request a lost password reset for"
+              exit 2
+            end
+
+            @config[:filters][:email] = ARGV[3]
+            @config[:username]        = ARGV[2]
+
+          when "set"
+            if (ARGV.length == 4 && ! @config[:password_flag]) || ! [ 4, 6 ].include?(ARGV.length)
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
+              exit 2
+            end
+
+            if ! [ :forum, :portal, :vpn ].include?(ARGV[2].to_sym)
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} has an invalid user password type, expected either forum, portal, or vpn"
+              exit 2
+            end
+
+            @config[:filters][:password_type] = ARGV[2].to_sym
+            @config[:username]                = [ ARGV[3] ]
+
+            if ARGV.length == 6
+              if ARGV[4] != ARGV[5]
+                $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} passwords do not match"
+                exit 2
+              end
+
+              @config[:password] = ARGV[4].to_s
+            elsif @config[:password_flag]
+              passwords = [ password_prompt, password_prompt(true) ]
+
+              if passwords[0] != passwords[1]
+                $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} passwords do not match"
+                exit 2
+              end
+
+              @config[:password] = passwords[0]
+            end
+
+          when "set-lost-password"
+            if ! [ 4, 5, 6, 7, 8, 9, 11 ].include?(ARGV.length)
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires passwords to be supplied either as arguments or read from STDIN using --password or -p option and " +
+                           "security question answers be supplied either as arguments with the id's or read from STDIN using --answer or -A option if needed"
+              exit 2
+            end
+
+            @config[:lost_password_key] = ARGV[2]
+
+            begin
+              lost_password_sec_questions = SoftLayer::Managers::Credentials.get_user_credentials_lost_password_sec_questions(@softlayer_client, @config[:lost_password_key])
+            rescue Exception => e
+              $stderr.puts "ERROR: Failed to get list of security questions for lost password reset: #{e.message}"
+              exit 1
+            end
+
+            sec_quest_count    = lost_password_sec_questions.length
+
+            if (sec_quest_count == 3 && ! [ 6, 8, 9, 11 ].include?(ARGV.length)) || (sec_quest_count == 1 && ! [ 4, 5, 6, 7 ].include?(ARGV.length))
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires passwords to be supplied either as arguments or read from STDIN using --password or -p option and " +
+                           "security question answers be supplied either as arguments with the id's or read from STDIN using --answer or -A option if needed"
+              exit 2
+            end
+
+            password_arg_range = (sec_quest_count == 3 ? [ 8, 11 ] : [ 6, 7 ])
+
+            if ! password_arg_range.include?(ARGV.length) && ! @config[:password_flag]
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires passwords to be supplied either as arguments or read from STDIN using --password or -p option"
+              exit 2
+            end
+
+            answer_arg_range = (sec_quest_count == 3 ? [ 9, 11 ] : [ 5, 7 ])
+
+            if ! answer_arg_range.include?(ARGV.length) && ! @config[:answer_flag]
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires security question answers be supplied either as arguments with the id's or read from STDIN using --answer or -A option if needed"
+              exit 2
+            end
+
+            @config[:filters][:security_question_ids] = (sec_quest_count == 3 ? [ ARGV[3], ARGV[4], ARGV[5] ] : [ ARGV[3] ])
+
+            if answer_arg_range.include?(ARGV.length)
+              @config[:answer] = ARGV.slice(6, 3) if sec_quest_count == 3
+              @config[:answer] = ARGV.slice(4, 1) if sec_quest_count == 1
+            end
+
+            if ! answer_arg_range.include?(ARGV.length) && @config[:answer_flag]
+              if sec_quest_count == 3
+                @config[:answer] = [ 
+                                    answer_prompt("for security question id #{ARGV[3]}"),
+                                    answer_prompt("for security question id #{ARGV[4]}"),
+                                    answer_prompt("for security question id #{ARGV[5]}")
+                                   ]
+              else
+                @config[:answer] = [ answer_prompt("for security question id #{ARGV[3]}") ]
+              end
+            end
+
+            if password_arg_range.include?(ARGV.length)
+              passwords = ARGV.slice(-2, 2)
+
+              if passwords[0] != passwords[1]
+                $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} passwords do not match"
+                exit 2
+              end
+
+              @config[:password] = passwords[0]
+            end
+
+
+            if ! password_arg_range.include?(ARGV.length) && @config[:password_flag]
+              passwords = [ password_prompt, password_prompt(true) ]
+
+              if passwords[0] != passwords[1]
+                $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} passwords do not match"
+                exit 2
+              end
+
+              @config[:password] = passwords[0]
+            end
+
+          when "set-sec-answers"
+            if (ARGV.length == 5 && ! @config[:answer_flag]) || ! [ 5, 8 ].include?(ARGV.length)
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires security question answers to be supplied either as arguments or read from STDIN using --answer or -A option"
+              exit 2
+            end
+
+            @config[:filters][:security_question_ids] = [ ARGV[2], ARGV[3], ARGV[4] ]
+
+            if ARGV.length == 8
+              @config[:answer] = ARGV.slice(5, 3)
+            elsif @config[:answer_flag]
+              @config[:answer] = [
+                                  answer_prompt("for security question id #{ARGV[2]}"),
+                                  answer_prompt("for security question id #{ARGV[3]}"),
+                                  answer_prompt("for security question id #{ARGV[4]}")
+                                 ]
+            end
+
+          end
+
+        end
       end
-
-      case ARGV[1]
-      when "delete", "list-details"
-        if ARGV.length < 3
-          $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires one or more software credential ID"
-          exit 2
-        end
-        @config[:action_args] = ARGV.slice(2, ARGV.length - 2)
-
-      when "set"
-        if ARGV.length != 3 && ! @config[:password_flag]
-          $stderr.puts "ERROR: #{ARGV[0]} action set requires a password be supplied either as an argument or read from STDIN using --password or -p option"
-          exit 2
-        end
-        
-        if ARGV.length == 3
-          @config[:password] = ARGV[2].to_s
-        elsif @config[:password_flag]
-          @config[:password] = password_prompt
-        end
-
-      else
-        if ARGV.length >= 3
-          $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} does not accept any arguments"
-          exit 2
-        end
-
-      end
-
-    when "storage"
-      @config[:category] = :storage
-
-      if ARGV[1] == nil
-        $stderr.puts "ERROR: No action provided for credential category #{ARGV[0]}"
-        exit 2
-      end
-
-      case ARGV[1]
-      when "list", "set"
-        @config[:action] = ARGV[1].to_sym
-
-      else
-        $stderr.puts "ERROR: Invalid action for credential category #{ARGV[0]}: #{ARGV[1]}"
-        exit 2
-
-      end
-
-      case ARGV[1]
-      when "set"
-        if ARGV.length != 3 && ! @config[:password_flag]
-          $stderr.puts "ERROR: #{ARGV[0]} action set requires a password be supplied either as an argument or read from STDIN using --password or -p option"
-          exit 2
-        end
-        
-        if ARGV.length == 3
-          @config[:password] = ARGV[2].to_s
-        elsif @config[:password_flag]
-          @config[:password] = password_prompt
-        end
-        
-      else
-        if ARGV.length >= 3
-          $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} does not accept any arguments"
-          exit 2
-        end
-        
-      end
-
-    else
-      unless @config[:help]
-        $stderr.puts "ERROR: Invalid credential category provided to perform action on"
-        exit 2
-      end
-
     end
   end
 
@@ -1251,6 +1826,9 @@ HELP_STOR_SET
         case opt
         when '--add'
           @config[:add_user_password] = true
+
+        when '--answer'
+          @config[:answer_flag] = true
 
         when '--datacenter', '--description', '--domain', '--hardware_type', '--hostname', '--manufacturer', '--name', '--storage_type', '--tag', '--vendor'
           @config[:filters][opt.slice(2, opt.length - 2).to_sym] = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}                           unless opt.to_s == '--storage_type'

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -22,16 +22,26 @@ module SoftLayer
         return true
       end
 
-      def self.get_user_credentials_lost_password_sec_questions(softlayer_client, lost_password_key)
+      def self.get_user_credentials_lost_password_sec_questions(softlayer_client, username, lost_password_key)
         raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a username"                   if !username || username.empty?
         raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a lost password reset key"    if !lost_password_key || lost_password_key.empty?
 
+        if softlayer_client.username != username
+          current_user = get_users(softlayer_client, { :filters => { :username => [ softlayer_client.username ] } }).first
+
+          raise "failed to find username #{softlayer_client.username}" if !current_user
+
+          unless current_user.service.isMasterUser
+            raise "cannot be run as a different user than your SoftLayer user, your SoftLayer user is not a master user"
+          end
+        end
 
         account_service = SoftLayer::Account.account_for_client(softlayer_client).service
-        current_user    = SoftLayer::UserCustomer.new(softlayer_client, account_service.object_mask(SoftLayer::UserCustomer.default_object_mask).getCurrentUser)
+        user            = get_users(softlayer_client, { :filters => { :username => [ username ] } }).first
 
-        sec_questions = current_user.service.getUserFromLostPasswordRequest(lost_password_key)
-        sec_questions = current_user.service.getDefaultSecurityQuestions(lost_password_key) if sec_questions.empty?
+        sec_questions = user.service.getUserFromLostPasswordRequest(lost_password_key)
+        sec_questions = user.service.getDefaultSecurityQuestions(lost_password_key) if sec_questions.empty?
 
         return sec_questions
       end
@@ -273,12 +283,22 @@ module SoftLayer
         return true
       end
 
-      def self.list_user_credentials_lost_password_sec_questions(softlayer_client, lost_password_key)
+      def self.list_user_credentials_lost_password_sec_questions(softlayer_client, username, lost_password_key)
         raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a username"                   if !username || username.empty?
         raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a lost password reset key"    if !lost_password_key || lost_password_key.empty?
 
+        if softlayer_client.username != username
+          current_user = get_users(softlayer_client, { :filters => { :username => [ softlayer_client.username ] } }).first
 
-        sec_questions = get_user_credentials_lost_password_sec_questions(softlayer_client, lost_password_key)
+          raise "failed to find username #{softlayer_client.username}" if !current_user
+
+          unless current_user.service.isMasterUser
+            raise "cannot be run as a different user than your SoftLayer user, your SoftLayer user is not a master user"
+          end
+        end
+
+        sec_questions = get_user_credentials_lost_password_sec_questions(softlayer_client, username, lost_password_key)
 
         sec_questions.map! { |sec_quest| [ sec_quest['id'], sec_quest['question'] ] }
 
@@ -480,27 +500,33 @@ module SoftLayer
         return true
       end
 
-      def self.set_user_credentials(softlayer_client, password, options = {})
+      def self.set_user_credentials(softlayer_client, username, password, password_type, options = {})
         raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance"                if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
         raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a password"                                  if !password || password.empty?
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a password_type of :forum, :portal, or :vpn" if !password_type || ![ :forum, :portal, :vpn ].include?(password_type)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a username"                                  if !username || username.empty?
 
         if !options[:yes_prompt]
-          return false unless yes_prompt("You are setting user #{options[:filters][:password_type]} credentials, this cannot be undone, continue?")
+          return false unless yes_prompt("You are setting user #{password_type} credentials, this cannot be undone, continue?")
         end
 
-        if ! options[:filters] || options[:filters].empty? || ! options[:filters][:password_type] || ! options[:filters][:username] || options[:filters][:username].empty?
-          raise ArgumentError, "user action set requires filter options password_type and username"
+        if softlayer_client.username != username
+          raise "forum password change cannot be run as another user, your SoftLayer user must match the user whose forum password is being changed" if password_type == :forum
+
+          current_user = get_users(softlayer_client, { :filters => { :username => [ softlayer_client.username ] } }).first
+
+          raise "failed to find username #{softlayer_client.username}" if !current_user
+
+          unless current_user.service.isMasterUser
+            raise "cannot be run as a different user than your SoftLayer user, your SoftLayer user is not a master user"
+          end
         end
 
-        if ! options[:yes_prompt]
-          return false unless yes_prompt("You are setting user #{options[:filters][:password_type]} credentials, this cannot be undone, continue?")
-        end
-
-        user = get_users(softlayer_client, options).first
+        user = get_users(softlayer_client, { :filters => { :username => [ username ] } }).first
 
         raise "failed to find username #{username}" if !user
 
-        case options[:filters][:password_type]
+        case password_type
         when :forum
           user.service.updateForumPassword(password)
         when :portal
@@ -512,59 +538,79 @@ module SoftLayer
         return true
       end
 
-      def self.set_user_credentials_lost_password(softlayer_client, lost_password_key, password, options = {})
+      def self.set_user_credentials_lost_password(softlayer_client, lost_password_key, username, password, security_question_answers, security_question_ids, options = {})
         raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
-        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a password"                   if !password || password.empty?
         raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a lost password reset key"    if !lost_password_key || lost_password_key.empty?
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a password"                   if !password || password.empty?
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a username"                   if !username || username.empty?
 
-        if !options[:filters] || options[:filters].empty? || !options[:filters][:security_question_ids] ||
-             options[:filters][:security_question_ids].empty? || ![ 1, 3 ].include?(options[:filters][:security_question_ids].length)
-          raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires three security question id's that correspond to each answer"
-        end
-
-        if !options[:filters] || options[:filters].empty? || !options[:filters][:answer] ||
-             options[:filters][:answer].empty? || ![ 1, 3 ].include?(options[:filters][:answer].length)
+        if !security_question_answers || security_question_answers.empty? || ![ 1, 3 ].include?(security_question_answers.length)
           raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires three security question answers's that correspond to each security question id"
         end
 
-        if options[:filters][:answer].length != options[:filters][:security_question_ids].length
+        if !security_question_ids || security_question_ids.empty? || ![ 1, 3 ].include?(security_question_ids.length)
+          raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires three security question id's that correspond to each answer"
+        end
+
+        if security_question_answers.length != security_question_ids.length
           raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires equal number security question answers and security question ids"
         end
 
-        sec_quest_answers = (0..(options[:filters][:answer].length - 1)).to_a.map do |sec_quest_index|
+        if softlayer_client.username != username
+          current_user = get_users(softlayer_client, { :filters => { :username => [ softlayer_client.username ] } }).first
+
+          raise "failed to find username #{softlayer_client.username}" if !current_user
+
+          unless current_user.service.isMasterUser
+            raise "cannot be run as a different user than your SoftLayer user, your SoftLayer user is not a master user"
+          end
+        end
+
+        sec_quest_answers = (0..(security_question_answers.length - 1)).to_a.map do |sec_quest_index|
           {
-            'answer'     => options[:filters][:answer][sec_quest_index],
-            'questionId' => options[:filters][:security_question_ids][sec_quest_index]
+            'answer'     => security_question_answers[sec_quest_index],
+            'questionId' => security_question_ids[sec_quest_index]
           }
         end
 
-        account_service = SoftLayer::Account.account_for_client(softlayer_client).service
-        current_user    = SoftLayer::UserCustomer.new(softlayer_client, account_service.object_mask(SoftLayer::UserCustomer.default_object_mask).getCurrentUser)
+        user = get_users(softlayer_client, { :filters => { :username => [ username ] } }).first
 
-        current_user.service.setPasswordFromLostPasswordRequest(lost_password_key, password, sec_quest_answers)
+        raise "failed to find username #{username}" if !user
+
+        user.service.setPasswordFromLostPasswordRequest(lost_password_key, password, sec_quest_answers)
       end
 
-      def self.set_user_credentials_sec_answers(softlayer_client, options = {})
+      def self.set_user_credentials_sec_answers(softlayer_client, username, security_question_ids, security_question_answers)
         raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a SoftLayer::Client instance" if !softlayer_client || !softlayer_client.kind_of?(SoftLayer::Client)
+        raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires a username"                   if !username || username.empty?
 
-        if !options[:filters] || options[:filters].empty? || !options[:filters][:security_question_ids] ||
-            options[:filters][:security_question_ids].empty? || options[:filters][:security_question_ids].length != 3
-          raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires three security question id's that correspond to each answer"
-        end
-
-        if !options[:filters] || options[:filters].empty? || !options[:filters][:answer] ||
-            options[:filters][:answer].empty? || options[:filters][:answer].length != 3
+        if !security_question_answers || security_question_answers.empty? || security_question_answers.length != 3
           raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires three security question answers's that correspond to each security question id"
         end
 
-        if options[:filters][:answer].length != options[:filters][:security_question_ids].length
+        if !security_question_ids || security_question_ids.empty? || security_question_ids.length != 3
+          raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires three security question id's that correspond to each answer"
+        end
+
+        if security_question_answers.length != security_question_ids.length
           raise ArgumentError, "SoftLayer Credential Manager #{__method__} requires equal number security question answers and security question ids"
         end
 
-        account_service = SoftLayer::Account.account_for_client(softlayer_client).service
-        current_user    = SoftLayer::UserCustomer.new(softlayer_client, account_service.object_mask(SoftLayer::UserCustomer.default_object_mask).getCurrentUser)
+        if softlayer_client.username != username
+          current_user = get_users(softlayer_client, { :filters => { :username => [ softlayer_client.username ] } }).first
 
-        current_user.service.updateSecurityAnswers(options[:filters][:security_question_ids].map { |sec_id| {'id' => sec_id } }, options[:filters][:answer])
+          raise "failed to find username #{softlayer_client.username}" if !current_user
+
+          unless current_user.service.isMasterUser
+            raise "cannot be run as a different user than your SoftLayer user, your SoftLayer user is not a master user"
+          end
+        end
+
+        user = get_users(softlayer_client, { :filters => { :username => [ username ] } }).first
+
+        raise "failed to find username #{username}" if !user
+
+        user.service.updateSecurityAnswers(security_question_ids.map { |sec_id| {'id' => sec_id } }, security_question_answers)
       end
 
       private
@@ -1301,16 +1347,18 @@ class VagrantSoftLayerCredentials
                  [ '--yes',             '-y', GetoptLong::NO_ARGUMENT       ]
                 ]
     @config   = {
-      :action            => nil,
-      :answer            => [],
-      :answer_flag       => false,
-      :add_user_password => false,
-      :category          => nil,
-      :filters           => {},
-      :help              => false,
-      :lost_password_key => nil,
-      :password          => nil,
-      :password_flag     => false,
+      :action                => nil,
+      :answer                => [],
+      :answer_flag           => false,
+      :add_user_password     => false,
+      :category              => nil,
+      :filters               => {},
+      :help                  => false,
+      :lost_password_key     => nil,
+      :password              => nil,
+      :password_flag         => false,
+      :password_type         => nil,
+      :security_question_ids => [],
       :show_password     => false,
       :sl_credentials    => {
         :api_key      => nil,
@@ -1761,7 +1809,7 @@ Usage: #{File.basename($0)} user list-details [options] <username>...
 HELP_USER_LIST_DETAILS
 
     @help[:user][:"list-lost-password-sec-questions"] = <<-HELP_LIST_LOST_PW_SEC_QUEST
-Usage: #{File.basename($0)} user list-lost-password-sec-questions [options] <lost_password_key>
+Usage: #{File.basename($0)} user list-lost-password-sec-questions [options] <lost_password_key> <username>
 
 #{@help[:std_opts]}
 HELP_LIST_LOST_PW_SEC_QUEST
@@ -1793,9 +1841,9 @@ Set Credential Options:
 HELP_USER_SET
 
     @help[:user][:"set-lost-password"] = <<-HELP_USER_SET_LOST_PW
-Usage: #{File.basename($0)} user set-lost-password [options] <lost_password_key> <sec_quest_id> <sec_quest_id> <sec_quest_id>
+Usage: #{File.basename($0)} user set-lost-password [options] <lost_password_key> <username> <sec_quest_id> <sec_quest_id> <sec_quest_id>
                                                             [<sec_quest_ans> <sec_quest_ans> <sec_quest_ans>] [<new_password> <confirm_password>]
-       #{File.basename($0)} user set-lost-password [options] <lost_password_key> <sec_quest_id> [<sec_quest_ans>]
+       #{File.basename($0)} user set-lost-password [options] <lost_password_key> <username> <sec_quest_id> [<sec_quest_ans>]
                                                             [<new_password> <confirm_password>]
 
 Note: If you have not yet set your account security questions, there will be a single default security question asked instead of the normal 3
@@ -1819,7 +1867,7 @@ Set Credential Options:
 HELP_USER_SET_LOST_PW
 
     @help[:user][:"set-sec-answers"] = <<-HELP_USER_SET_SEC_ANS
-Usage: #{File.basename($0)} user set-sec-answers [options] <sec_quest_id> <sec_quest_id> <sec_quest_id>
+Usage: #{File.basename($0)} user set-sec-answers [options] <username> <sec_quest_id> <sec_quest_id> <sec_quest_id>
                                                           [<sec_quest_ans> <sec_quest_ans> <sec_quest_ans>]
 
 Set Credential Options:
@@ -1992,6 +2040,7 @@ HELP_USER_SET_SEC_ANS
 
         when :"list-lost-password-sec-questions"
           exit 1 unless SoftLayer::Managers::Credentials.list_user_credentials_lost_password_sec_questions(@softlayer_client,
+                                                                                                           @config[:username].first,
                                                                                                            @config[:lost_password_key])
 
         when :"list-sec-questions"
@@ -2005,29 +2054,25 @@ HELP_USER_SET_SEC_ANS
                                                                                                      :filters => @config[:filters])
 
         when :set
-          set_filter            = @config[:filters]
-          set_filter[:username] = @config[:username]
-
           exit 1 unless SoftLayer::Managers::Credentials.set_user_credentials(@softlayer_client,
+                                                                              @config[:username].first,
                                                                               @config[:password],
-                                                                              :filters    => @config[:filters],
+                                                                              @config[:password_type],
                                                                               :yes_prompt => @config[:yes_prompt])
 
         when :"set-lost-password"
-          set_filter            = @config[:filters]
-          set_filter[:answer]   = @config[:answer]
-
           exit 1 unless SoftLayer::Managers::Credentials.set_user_credentials_lost_password(@softlayer_client,
                                                                                             @config[:lost_password_key],
+                                                                                            @config[:username].first,
                                                                                             @config[:password],
-                                                                                            :filters => @config[:filters])
+                                                                                            @conifg[:security_question_ids],
+                                                                                            @config[:answer])
 
         when :"set-sec-answers"
-          set_filter            = @config[:filters]
-          set_filter[:answer]   = @config[:answer]
-
           exit 1 unless SoftLayer::Managers::Credentials.set_user_credentials_sec_answers(@softlayer_client,
-                                                                                          :filters => @config[:filters])
+                                                                                          @config[:username].first,
+                                                                                          @conifg[:security_question_ids],
+                                                                                          @config[:answer])
 
         end
 
@@ -2202,12 +2247,13 @@ HELP_USER_SET_SEC_ANS
             @config[:username] = ARGV.slice(2, ARGV.length - 2)
 
           when "list-lost-password-sec-questions"
-            if ARGV.length != 3
-              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a lost password reset key"
+            if ARGV.length != 4
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a username and lost password reset key"
               exit 2
             end
 
             @config[:lost_password_key] = ARGV[2]
+            @config[:username]          = [ ARGV[3] ]
 
           when "lost-password"
             if ARGV.length != 4
@@ -2229,8 +2275,8 @@ HELP_USER_SET_SEC_ANS
               exit 2
             end
 
-            @config[:filters][:password_type] = ARGV[2].to_sym
-            @config[:username]                = [ ARGV[3] ]
+            @config[:password_type] = ARGV[2].to_sym
+            @config[:username]      = [ ARGV[3] ]
 
             if ARGV.length == 6
               if ARGV[4] != ARGV[5]
@@ -2251,16 +2297,17 @@ HELP_USER_SET_SEC_ANS
             end
 
           when "set-lost-password"
-            if ![ 4, 5, 6, 7, 8, 9, 11 ].include?(ARGV.length)
+            if ![ 5, 6, 7, 8, 9, 10, 12 ].include?(ARGV.length)
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires passwords to be supplied either as arguments or read from STDIN using --password or -p option and " +
                            "security question answers be supplied either as arguments with the id's or read from STDIN using --answer or -A option if needed"
               exit 2
             end
 
             @config[:lost_password_key] = ARGV[2]
+            @config[:username]          = [ ARGV[3] ]
 
             begin
-              lost_password_sec_questions = SoftLayer::Managers::Credentials.get_user_credentials_lost_password_sec_questions(@softlayer_client, @config[:lost_password_key])
+              lost_password_sec_questions = SoftLayer::Managers::Credentials.get_user_credentials_lost_password_sec_questions(@softlayer_client, @config[:username].first, @config[:lost_password_key])
             rescue Exception => e
               $stderr.puts "ERROR: Failed to get list of security questions for lost password reset: #{e.message}"
               exit 1
@@ -2268,42 +2315,42 @@ HELP_USER_SET_SEC_ANS
 
             sec_quest_count    = lost_password_sec_questions.length
 
-            if (sec_quest_count == 3 && ![ 6, 8, 9, 11 ].include?(ARGV.length)) || (sec_quest_count == 1 && ![ 4, 5, 6, 7 ].include?(ARGV.length))
+            if (sec_quest_count == 3 && ![ 7, 9, 10, 12 ].include?(ARGV.length)) || (sec_quest_count == 1 && ![ 5, 6, 7, 8 ].include?(ARGV.length))
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires passwords to be supplied either as arguments or read from STDIN using --password or -p option and " +
                            "security question answers be supplied either as arguments with the id's or read from STDIN using --answer or -A option if needed"
               exit 2
             end
 
-            password_arg_range = (sec_quest_count == 3 ? [ 8, 11 ] : [ 6, 7 ])
+            password_arg_range = (sec_quest_count == 3 ? [ 9, 12 ] : [ 7, 8 ])
 
             if !password_arg_range.include?(ARGV.length) && !@config[:password_flag]
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires passwords to be supplied either as arguments or read from STDIN using --password or -p option"
               exit 2
             end
 
-            answer_arg_range = (sec_quest_count == 3 ? [ 9, 11 ] : [ 5, 7 ])
+            answer_arg_range = (sec_quest_count == 3 ? [ 10, 12 ] : [ 6, 8 ])
 
             if !answer_arg_range.include?(ARGV.length) && !@config[:answer_flag]
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires security question answers be supplied either as arguments with the id's or read from STDIN using --answer or -A option if needed"
               exit 2
             end
 
-            @config[:filters][:security_question_ids] = (sec_quest_count == 3 ? [ ARGV[3], ARGV[4], ARGV[5] ] : [ ARGV[3] ])
+            @config[:security_question_ids] = (sec_quest_count == 3 ? [ ARGV[4], ARGV[5], ARGV[6] ] : [ ARGV[4] ])
 
             if answer_arg_range.include?(ARGV.length)
-              @config[:answer] = ARGV.slice(6, 3) if sec_quest_count == 3
-              @config[:answer] = ARGV.slice(4, 1) if sec_quest_count == 1
+              @config[:answer] = ARGV.slice(7, 3) if sec_quest_count == 3
+              @config[:answer] = ARGV.slice(5, 1) if sec_quest_count == 1
             end
 
             if !answer_arg_range.include?(ARGV.length) && @config[:answer_flag]
               if sec_quest_count == 3
-                @config[:answer] = [ 
-                                    answer_prompt("for security question id #{ARGV[3]}"),
+                @config[:answer] = [
                                     answer_prompt("for security question id #{ARGV[4]}"),
-                                    answer_prompt("for security question id #{ARGV[5]}")
+                                    answer_prompt("for security question id #{ARGV[5]}"),
+                                    answer_prompt("for security question id #{ARGV[6]}")
                                    ]
               else
-                @config[:answer] = [ answer_prompt("for security question id #{ARGV[3]}") ]
+                @config[:answer] = [ answer_prompt("for security question id #{ARGV[4]}") ]
               end
             end
 
@@ -2331,20 +2378,21 @@ HELP_USER_SET_SEC_ANS
             end
 
           when "set-sec-answers"
-            if (ARGV.length == 5 && !@config[:answer_flag]) || ![ 5, 8 ].include?(ARGV.length)
+            if (ARGV.length == 6 && !@config[:answer_flag]) || ![ 6, 9 ].include?(ARGV.length)
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires security question answers to be supplied either as arguments or read from STDIN using --answer or -A option"
               exit 2
             end
 
-            @config[:filters][:security_question_ids] = [ ARGV[2], ARGV[3], ARGV[4] ]
+            @config[:security_question_ids] = [ ARGV[3], ARGV[4], ARGV[5] ]
+            @config[:username]              = [ ARGV[2] ]
 
             if ARGV.length == 8
-              @config[:answer] = ARGV.slice(5, 3)
+              @config[:answer] = ARGV.slice(6, 3)
             elsif @config[:answer_flag]
               @config[:answer] = [
-                                  answer_prompt("for security question id #{ARGV[2]}"),
                                   answer_prompt("for security question id #{ARGV[3]}"),
-                                  answer_prompt("for security question id #{ARGV[4]}")
+                                  answer_prompt("for security question id #{ARGV[4]}"),
+                                  answer_prompt("for security question id #{ARGV[5]}")
                                  ]
             end
 

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -8,6 +8,20 @@ require 'softlayer_api'
 module SoftLayer
   module Managers
     class Credentials
+      def self.delete_software_credentials(softlayer_client, software_password_ids, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if ! options[:yes_prompt]
+          return false unless yes_prompt("You are deleting one or more software credentials, this cannot be undone, continue?")
+        end
+
+        software_password_service = softlayer_client[:Software_Component_Password]
+        software_password_service.deleteObjects(software_password_ids.map { |sw_pw_id| { 'id' => sw_pw_id } })
+
+        return true
+      end
+
       def self.get_user_credentials_lost_password_sec_questions(softlayer_client, lost_password_key)
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
@@ -25,20 +39,6 @@ module SoftLayer
         return sec_questions
       end
 
-      def self.delete_software_credentials(softlayer_client, software_password_ids, options = {})
-        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
-
-        if ! options[:yes_prompt]
-          return false unless yes_prompt("You are deleting one or more software credentials, this cannot be undone, continue?")
-        end
-
-        software_password_service = softlayer_client[:Software_Component_Password]
-        software_password_service.deleteObjects(software_password_ids.map { |sw_pw_id| { 'id' => sw_pw_id } })
-
-        return true
-      end
-
       def self.list_network_message_delivery_credentials(softlayer_client, options = {})
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
@@ -47,7 +47,7 @@ module SoftLayer
           return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
         end
 
-        account_service             = softlayer_client['SoftLayer_Account']
+        account_service             = softlayer_client[:SoftLayer_Account]
         net_msg_deliv_accts         = [ [ 'id', 'username', 'password', 'vendor' ] ]
         net_msg_deliv_object_filter = network_message_delivery_filters(options)
 
@@ -60,6 +60,28 @@ module SoftLayer
         end
 
         pretty_print_table(net_msg_deliv_accts)
+
+        return true
+      end
+
+      def self.list_network_vlan_firewall_credentials(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+          return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
+        end
+
+        vlan_fw_software_passwords = get_network_vlan_firewall_passwords(softlayer_client, options)
+
+        software_passwords = []
+
+        vlan_fw_software_passwords.each { |vlan_fw, sw_pw| software_passwords.push([ sw_pw['id'].to_s, sw_pw.username, sw_pw.password, vlan_fw ]) }
+
+        software_passwords.sort_by! { |element| element[1] }
+        software_passwords.unshift([ "id", "username", "password", "vlan firewall fqdn" ])
+
+        pretty_print_table(software_passwords)
 
         return true
       end
@@ -263,7 +285,7 @@ module SoftLayer
           return false unless yes_prompt("You are setting one or more network message delivery credentials, this cannot be undone, continue?")
         end
 
-        account_service             = softlayer_client['SoftLayer_Account']
+        account_service             = softlayer_client[:SoftLayer_Account]
         net_msg_deliv_object_filter = network_message_delivery_filters(options)
 
         account_service             = account_service.object_filter(net_msg_deliv_object_filter) unless net_msg_deliv_object_filter.empty?
@@ -271,6 +293,38 @@ module SoftLayer
         net_msg_deliv_accts         = account_service.getNetworkMessageDeliveryAccounts.collect{|net_msg_deliv_acct| SoftLayer::NetworkMessageDelivery.new(softlayer_client, net_msg_deliv_acct)}
 
         net_msg_deliv_accts.each{|net_msg_deliv_acct| net_msg_deliv_acct.password= password}
+
+        return true
+      end
+
+      def self.set_network_vlan_firewall_credentials(softlayer_client, password, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if ! password || password.empty?
+          raise ArgumentError, "network_vlan_firewall action set requires a non nil or empty password"
+        end
+
+        if (! options[:filters] || options[:filters].empty?) && (! options[:yes_prompt])
+          return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
+        end
+
+        if ! options[:yes_prompt]
+          return false unless yes_prompt("You are setting one or more network_vlan_firewall credentials, this cannot be undone, continue?")
+        end
+
+        object_filters = network_vlan_firewall_filters(options)
+
+        vlan_space = (options[:filters] && options[:filters][:space]) ? options[:filters][:space] : :all
+
+        software_passwords = SoftLayer::SoftwarePassword.find_passwords_for_vlan_firewalls(:client                          => softlayer_client,
+                                                                                           :software_password_object_filter => object_filters[:software_password],
+                                                                                           :software_password_object_mask   => software_password_mask(:list),
+                                                                                           :vlan_object_filter              => object_filters[:vlan],
+                                                                                           :vlan_firewall_object_filter     => object_filters[:vlan_firewall],
+                                                                                           :vlan_space                      => vlan_space)
+
+        SoftLayer::SoftwarePassword.update_passwords(software_passwords, password, :client => softlayer_client)
 
         return true
       end
@@ -483,6 +537,51 @@ module SoftLayer
         software_password_service.createObjects(software_passwords_template.flatten.compact)
       end
 
+      def self.get_network_vlan_firewall_passwords(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        object_filters = network_vlan_firewall_filters(options)
+
+        vlan_space = (options[:filters] && options[:filters][:space]) ? options[:filters][:space] : :all
+
+        account_service = softlayer_client[:Account]
+        account_service = account_service.object_filter(object_filters[:vlan]) unless object_filters[:vlan].empty?
+        account_service = account_service.object_mask("mask[id]")
+
+        case vlan_space
+        when :all
+          vlan_data = account_service.getNetworkVlans
+        when :private
+          vlan_data = account_service.getPrivateNetworkVlans
+        when :public
+          vlan_data = account_service.getPublicNetworkVlans
+        end
+
+        vlan_fw_passwords = {}
+
+        vlan_data.each do |vlan|
+          vlan_service = softlayer_client[:Network_Vlan].object_with_id(vlan['id'])
+          vlan_service = vlan_service.object_filter(object_filters[:vlan_firewall]) unless object_filters[:vlan_firewall].empty?
+          vlan_service = vlan_service.object_mask("mask[id,fullyQualifiedDomainName]")
+
+          vlan_fw = vlan_service.getNetworkVlanFirewall
+
+          unless vlan_fw.empty?
+            vlan_fw_service = softlayer_client[:Network_Vlan_Firewall].object_with_id(vlan_fw['id'])
+            vlan_fw_service = vlan_fw_service.object_filter(object_filters[:software_password]) unless object_filters[:software_password].empty?
+            vlan_fw_service = vlan_fw_service.object_mask(SoftLayer::SoftwarePassword.default_object_mask)
+            vlan_fw_service = vlan_fw_service.object_mask(software_password_mask(:list))
+
+            vlan_fw_password_data = vlan_fw_service.getManagementCredentials
+
+            vlan_fw_passwords[vlan_fw['fullyQualifiedDomainName']] = SoftwarePassword.new(softlayer_client, vlan_fw_password_data) unless vlan_fw_password_data.empty?
+          end
+        end
+
+        return vlan_fw_passwords
+      end
+
       def self.get_software_passwords(softlayer_client, options = {})
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
@@ -692,6 +791,65 @@ module SoftLayer
         end
 
         return net_msg_deliv_object_filter
+      end
+
+      def self.network_vlan_firewall_filters(options = {})
+        filter_label = {
+          :all     => 'networkVlans',
+          :private => 'privateNetworkVlans',
+          :public  => 'publicNetworkVlans'
+        }
+
+        option_to_filter_path = {
+          :software_password => {
+            :username        => "managementCredentials.username"
+          },
+          :vlan => {
+            :name        => lambda { |vlan_space| return [ filter_label[vlan_space], '.', 'name' ].join       },
+            :vlan_number => lambda { |vlan_space| return [ filter_label[vlan_space], '.', 'vlanNumber' ].join },
+          },
+          :vlan_dedicated_fw => lambda { |vlan_space| return [ filter_label[vlan_space], '.', 'dedicatedFirewallFlag' ].join  },
+          :vlan_firewall     => {
+            :datacenter => "networkVlanFirewall.datacenter.name",
+            :fqdn       => "networkVlanFirewall.fullyQualifiedDomainName",
+            :tags       => "networkVlanFirewall.tagReferences.tag.name",
+            :type       => "networkVlanFirewall.firewallType"
+          }
+        }
+
+        software_password_object_filter = ObjectFilter.new()
+        vlan_object_filter              = ObjectFilter.new()
+        vlan_firewall_object_filter     = ObjectFilter.new()
+
+        vlan_space = (options[:filters] && options[:filters][:space]) ? options[:filters][:space] : :all
+
+        vlan_object_filter.modify { |filter| filter.accept(option_to_filter_path[:vlan_dedicated_fw].call(vlan_space)).when_it is(1) }
+
+        if options[:filters]
+          option_to_filter_path[:software_password].each do |option, filter_path|
+            if options[:filters][option] && ! options[:filters][option].empty?
+              object_filter_criteria_contains(software_password_object_filter, filter_path, options[:filters][option])
+            end
+          end
+
+          option_to_filter_path[:vlan].each do |option, filter_path|
+            if options[:filters][option] && ! options[:filters][option].empty?
+              object_filter_criteria_contains(vlan_object_filter, filter_path.call(vlan_space), options[:filters][option])
+            end
+          end
+
+          option_to_filter_path[:vlan_firewall].each do |option, filter_path|
+            if options[:filters][option] && ! options[:filters][option].empty?
+              object_filter_criteria_contains(vlan_firewall_object_filter, filter_path, options[:filters][option])
+            end
+          end
+        end
+
+        {
+          :software_password => software_password_object_filter,
+          :vlan              => vlan_object_filter,
+          :vlan_firewall     => vlan_firewall_object_filter
+        }
       end
 
       def self.software_password_filters(filter_type, options = {})
@@ -971,6 +1129,7 @@ class VagrantSoftLayerCredentials
                  [ '--datacenter',      '-d', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--description',           GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--domain',          '-D', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--fqdn',            '-f', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--hardware',              GetoptLong::NO_ARGUMENT       ],
                  [ '--hardware_type',         GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--hostname',        '-H', GetoptLong::REQUIRED_ARGUMENT ],
@@ -982,11 +1141,14 @@ class VagrantSoftLayerCredentials
                  [ '--sl_endpoint_url', '-e', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--sl_timeout',      '-t', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--sl_username',     '-u', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--space',           '-S', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--storage_type',    '-s', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--tag',             '-T', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--type',                  GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--username',        '-U', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--vendor',          '-v', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--virtual_servers',       GetoptLong::NO_ARGUMENT       ],
+                 [ '--vlan_number',     '-N', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--yes',             '-y', GetoptLong::NO_ARGUMENT       ]
                 ]
     @config   = {
@@ -1012,6 +1174,7 @@ class VagrantSoftLayerCredentials
     }
     @help = {
       :network_message_delivery => {},
+      :network_vlan_firewall    => {},
       :software                 => {},
       :storage                  => {},
       :user                     => {}
@@ -1057,6 +1220,11 @@ network_message_delivery:
   set                               Set credential password for username(s) related to network message
                                     delivery services.
 
+network_vlan_firewall:
+  list                              List credential username/password(s) for network VLAN firewall services.
+  set                               Set credential password for username(s) related to network VLAN firewall
+                                    services.
+
 software:
   delete                            Delete credential username/password(s) for installed software.
   list                              List credential username/password(s) for installed software.
@@ -1089,6 +1257,28 @@ Network Message Delivery Filter Options:
 --vendor|-v <VENDOR>,...:
     Include network message delivery credentials whose vendor matches this list of vendors.
 HELP_NMD_FILTERS
+
+    @help[:network_vlan_firewall_filters] = <<-HELP_NVF_FILTERS
+Network VLAN Firewall Filter Options:
+
+--datacenter|-d <DATACENTER>,...:
+    Include network VLAN firewall credentials from firewalls matching this list of datacenters.
+
+--fqdn|-f <FQDN>,...:
+    Include network VLAN firewall credentials from firewalls matching this list of fqdn's.
+
+--name|-n <VLAN_NAME>,...:
+    Include network VLAN firewall credentials from firewalls whose associated VLAN matches these names.
+
+--vlan_number|-N <VLAN_NUMBER>,...:
+    Include network VLAN firewall credentials from firewalls whose associated VLAN matches these VLAN numbers.
+
+--tag|-T <TAG>,...:
+    Include network VLAN firewall credentials from firewalls with tags matching this list of tags.
+
+--type <TYPE>,..."
+    Include network VLAN firewall credentials from firewalls matching this list of types.
+HELP_NVF_FILTERS
 
     @help[:software_filters]             = <<-HELP_SW_FILTERS
 Software Filter Options:
@@ -1178,9 +1368,9 @@ Set Credential Options:
     takes precedence and the password will not be read.
 
 --username|-u <USERNAME>,...:
-    Set the software credential password for these username(s) only. If not specified, the password
-    will be set for all software credentials that match other filtering criteria regardless
-    of username.
+    Set the network message delivery credential password for these username(s) only.
+    If not specified, the password will be set for all network message delivery
+    credentials that match other filtering criteria regardless of username.
 
 --yes|-y:
     Automatic yes to prompt(s).
@@ -1188,6 +1378,46 @@ Set Credential Options:
 #{@help[:network_message_delivery_filters]}
 #{@help[:std_opts]}
 HELP_NMD_SET
+
+    @help[:network_vlan_firewall][:list] = <<-HELP_NVF_LIST
+Usage: #{File.basename($0)} network_vlan_firewall list [options]
+
+List Credential Options:
+
+--username|-u <USERNAME>,...:
+    List the network VLAN firewall credential(s) for these username(s) only.
+
+--yes|-y:
+    Automatic yes to prompt(s).
+
+#{@help[:network_vlan_firewall_filters]}
+#{@help[:std_opts]}
+HELP_NVF_LIST
+
+    @help[:network_vlan_firewall][:set] = <<-HELP_NVF_SET
+Usage: #{File.basename($0)} network_vlan_firewall set [options]
+
+<password> - The password to set for credential(s) matching option filters.
+
+Set Credential Options:
+
+--password|-p:
+    Prompt for password from STDIN instead of expecting password as an argument.
+    If not specified, it is expected that password is provided as an argument to
+    the action. If both the argument and this option are provided, the argument
+    takes precedence and the password will not be read.
+
+--username|-u <USERNAME>,...:
+    Set the network VLAN firewall credential password for these username(s) only. If not specified,
+    the password will be set for all network VLAN firewall credentials that match other filtering
+    criteria regardless of username.
+
+--yes|-y:
+    Automatic yes to prompt(s).
+
+#{@help[:network_vlan_firewall_filters]}
+#{@help[:std_opts]}
+HELP_NVF_SET
 
     @help[:software][:delete] = <<-HELP_SW_DELETE
 Usage: #{File.basename($0)} software delete [options] <ID>...
@@ -1280,9 +1510,9 @@ Set Credential Options:
     takes precedence and the password will not be read.
 
 --username|-u <USERNAME>,...:
-    Set the software credential password for these username(s) only. If not specified, the password
-    will be set for all software credentials that match other filtering criteria regardless
-    of username.
+    Set the storage credential password for these username(s) only. If not specified,
+    the password will be set for all storage credentials that match other filtering
+    criteria regardless of username.
 
 --yes|-y:
     Automatic yes to prompt(s).
@@ -1421,6 +1651,28 @@ HELP_USER_SET_SEC_ANS
                                                                                                   :yes_prompt => @config[:yes_prompt])
 
         end
+
+      when :network_vlan_firewall
+        case @config[:action]
+        when :list
+          list_filter            = @config[:filters]
+          list_filter[:username] = @config[:username] unless @config[:username].empty?
+
+          exit 1 unless SoftLayer::Managers::Credentials.list_network_vlan_firewall_credentials(@softlayer_client,
+                                                                                                :filters    => list_filter,
+                                                                                                :yes_prompt => @config[:yes_prompt])
+
+        when :set
+          set_filter            = @config[:filters]
+          set_filter[:username] = @config[:username] unless @config[:username].empty?
+
+          exit 1 unless SoftLayer::Managers::Credentials.set_software_credentials(@softlayer_client,
+                                                                                  @config[:password],
+                                                                                  :filters    => @config[:filters],
+                                                                                  :yes_prompt => @config[:yes_prompt])
+
+        end
+
       when :software
         case @config[:action]
         when :delete
@@ -1559,6 +1811,10 @@ HELP_USER_SET_SEC_ANS
         :actions       => [ :list, :set ],
         :accept_params => [ :set ]
       },
+      :network_vlan_firewall    => {
+        :actions       => [ :list, :set ],
+        :accept_params => [ :set ]
+      },
       :software                 => {
         :actions       => [ :delete, :list, :"list-details", :set ],
         :accept_params => [ :delete, :"list-details", :set ]
@@ -1602,6 +1858,20 @@ HELP_USER_SET_SEC_ANS
       if ! @config[:help]
         case ARGV[0]
         when "network_message_delivery"
+          if ARGV[1] == "set"
+            if (ARGV.length == 2 && ! @config[:password_flag]) || ! [ 2, 3 ].include?(ARGV.length)
+              $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
+              exit 2
+            end
+
+            if ARGV.length == 3
+              @config[:password] = ARGV[2].to_s
+            elsif @config[:password_flag]
+              @config[:password] = password_prompt
+            end
+          end
+
+        when "network_vlan_firewall"
           if ARGV[1] == "set"
             if (ARGV.length == 2 && ! @config[:password_flag]) || ! [ 2, 3 ].include?(ARGV.length)
               $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} requires a password be supplied either as an argument or read from STDIN using --password or -p option"
@@ -1830,7 +2100,7 @@ HELP_USER_SET_SEC_ANS
         when '--answer'
           @config[:answer_flag] = true
 
-        when '--datacenter', '--description', '--domain', '--hardware_type', '--hostname', '--manufacturer', '--name', '--storage_type', '--tag', '--vendor'
+        when '--datacenter', '--description', '--domain', '--fqdn', '--hardware_type', '--hostname', '--manufacturer', '--name', '--storage_type', '--tag', '--type', '--vendor', '--vlan_number'
           @config[:filters][opt.slice(2, opt.length - 2).to_sym] = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}                           unless opt.to_s == '--storage_type'
           @config[:filters][:network_storage_type]               = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}.map{|token| token.to_sym} if     opt.to_s == '--storage_type'
 
@@ -1859,6 +2129,14 @@ HELP_USER_SET_SEC_ANS
 
         when '--sl_username'
           @config[:sl_credentials][:username] = optval.to_s
+
+        when '--space'
+          if ! [ :all, :public, :private ].include?(optval.to_sym)
+            $stderr.puts "ERROR: Network VLAN space filter must be a value of all, public, or private"
+            exit 2
+          end
+
+          @config[:filters][:space] = optval.to_sym
 
         when '--username'
           @config[:username] = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -539,6 +539,10 @@ Usage: #{File.basename($0)} <category> <action> [<args>...] [<options>...]
 
 The following credential management categories and associated actions are available:
 
+network_message_delivery:
+  list          List credential username/password(s) for network message delivery services.
+  set           Set credential password for username(s) related to network message delivery services.
+
 software:
   delete        Delete credential username/password(s) for installed software.
   list          List credential username/password(s) for installed software.

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -51,10 +51,19 @@ module SoftLayer
 
         software_passwords = []
 
-        app_delivery_controller_passwords.each { |management_ip, sw_pw| software_passwords.push([ sw_pw['id'].to_s, sw_pw.username, sw_pw.password, management_ip ]) }
+        if options[:show_password]
+          app_delivery_controller_passwords.each { |management_ip, sw_pw| software_passwords.push([ sw_pw['id'].to_s, sw_pw.username, sw_pw.password, management_ip ]) }
+        else
+          app_delivery_controller_passwords.each { |management_ip, sw_pw| software_passwords.push([ sw_pw['id'].to_s, sw_pw.username, management_ip ]) }
+        end
 
         software_passwords.sort_by! { |element| element[1] }
-        software_passwords.unshift([ "id", "username", "password", "management_ip" ])
+
+        if options[:show_password]
+          software_passwords.unshift([ "id", "username", "password", "management_ip" ])
+        else
+          software_passwords.unshift([ "id", "username", "management_ip" ])
+        end
 
         pretty_print_table(software_passwords)
 
@@ -70,7 +79,7 @@ module SoftLayer
         end
 
         account_service             = softlayer_client[:SoftLayer_Account]
-        net_msg_deliv_accts         = [ [ 'id', 'username', 'password', 'vendor' ] ]
+        net_msg_deliv_accts         = options[:show_password] ? [ [ 'id', 'username', 'password', 'vendor' ] ] : [ [ 'id', 'username', 'vendor' ] ]
         net_msg_deliv_object_filter = network_message_delivery_filters(options)
 
         account_service             = account_service.object_filter(net_msg_deliv_object_filter) unless net_msg_deliv_object_filter.empty?
@@ -78,7 +87,11 @@ module SoftLayer
         net_msg_deliv_accts_details = account_service.getNetworkMessageDeliveryAccounts
 
         net_msg_deliv_accts_details.each do |net_msg_deliv_acct|
-          net_msg_deliv_accts.push([ net_msg_deliv_acct['id'].to_s, net_msg_deliv_acct['username'], net_msg_deliv_acct['password'], net_msg_deliv_acct['vendor']['name'] ])
+          if options[:show_password]
+            net_msg_deliv_accts.push([ net_msg_deliv_acct['id'].to_s, net_msg_deliv_acct['username'], net_msg_deliv_acct['password'], net_msg_deliv_acct['vendor']['name'] ])
+          else
+            net_msg_deliv_accts.push([ net_msg_deliv_acct['id'].to_s, net_msg_deliv_acct['username'], net_msg_deliv_acct['vendor']['name'] ])
+          end
         end
 
         pretty_print_table(net_msg_deliv_accts)
@@ -98,17 +111,26 @@ module SoftLayer
 
         software_passwords = []
 
-        vlan_fw_software_passwords.each { |vlan_fw, sw_pw| software_passwords.push([ sw_pw['id'].to_s, sw_pw.username, sw_pw.password, vlan_fw ]) }
+        if options[:show_password]
+          vlan_fw_software_passwords.each { |vlan_fw, sw_pw| software_passwords.push([ sw_pw['id'].to_s, sw_pw.username, sw_pw.password, vlan_fw ]) }
+        else
+          vlan_fw_software_passwords.each { |vlan_fw, sw_pw| software_passwords.push([ sw_pw['id'].to_s, sw_pw.username, vlan_fw ]) }
+        end
 
         software_passwords.sort_by! { |element| element[1] }
-        software_passwords.unshift([ "id", "username", "password", "vlan firewall fqdn" ])
+
+        if options[:show_password]
+          software_passwords.unshift([ "id", "username", "password", "vlan firewall fqdn" ])
+        else
+          software_passwords.unshift([ "id", "username", "vlan firewall fqdn" ])
+        end
 
         pretty_print_table(software_passwords)
 
         return true
       end
 
-      def self.list_software_credential_details(softlayer_client, software_password_ids)
+      def self.list_software_credential_details(softlayer_client, software_password_ids, options = {})
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
@@ -124,7 +146,7 @@ module SoftLayer
 
           software_password_details.push([ 'id',            software_password['id'].to_s ])
           software_password_details.push([ 'username',      software_password['username'] ])
-          software_password_details.push([ 'password',      software_password['password'] ])
+          software_password_details.push([ 'password',      software_password['password'] ]) if options[:show_password]
           software_password_details.push([ 'last modified', software_password['modifyDate'] ])
           software_password_details.push([ 'port',          software_password['port'] || "" ])
           software_password_details.push([ 'notes',         software_password['notes'] || "" ])
@@ -153,9 +175,19 @@ module SoftLayer
 
         software_passwords = get_software_passwords(softlayer_client, options)
 
-        software_passwords.map! { |sw_pw| [ sw_pw['id'].to_s, sw_pw['software']['softwareDescription']['name'], sw_pw.username, sw_pw.password ] }
+        if options[:show_password]
+          software_passwords.map! { |sw_pw| [ sw_pw['id'].to_s, sw_pw['software']['softwareDescription']['name'], sw_pw.username, sw_pw.password ] }
+        else
+          software_passwords.map! { |sw_pw| [ sw_pw['id'].to_s, sw_pw['software']['softwareDescription']['name'], sw_pw.username ] }
+        end
+
         software_passwords.sort_by! { |element| element[1] }
-        software_passwords.unshift([ "id", "software name", "username", "password" ])
+
+        if options[:show_password]
+          software_passwords.unshift([ "id", "software name", "username", "password" ])
+        else
+          software_passwords.unshift([ "id", "software name", "username" ])
+        end
 
         pretty_print_table(software_passwords)
 
@@ -172,25 +204,41 @@ module SoftLayer
 
         storage_credentials_by_username = {}
         storage_credentials_data        = get_storage_credentials(softlayer_client, options)
-        storage_credentials_table       = [ [ "id", "username", "password", "storage type" ] ]
+        storage_credentials_table       = options[:show_password] ? [ [ "id", "username", "password", "storage type" ] ] : [ [ "id", "username", "storage type" ] ]
 
         storage_credentials_data.each do |storage_service, storage_credentials|
-          storage_credentials_by_username[storage_credentials[:primary_credential][:username]] = [
-                                                                                                  nil,
-                                                                                                  storage_credentials[:primary_credential][:username],
-                                                                                                  storage_credentials[:primary_credential][:password],
-                                                                                                  storage_credentials[:type]
-                                                                                                 ]
+          if options[:show_password]
+            storage_credentials_by_username[storage_credentials[:primary_credential][:username]] = [
+                                                                                                    nil,
+                                                                                                    storage_credentials[:primary_credential][:username],
+                                                                                                    storage_credentials[:primary_credential][:password],
+                                                                                                    storage_credentials[:type]
+                                                                                                   ]
+          else
+            storage_credentials_by_username[storage_credentials[:primary_credential][:username]] = [
+                                                                                                    nil,
+                                                                                                    storage_credentials[:primary_credential][:username],
+                                                                                                    storage_credentials[:type]
+                                                                                                   ]
+          end
         end
 
         storage_credentials_data.each do |storage_service, storage_credentials|
           storage_credentials[:secondary_credentials].each do |storage_credential|
-            storage_credentials_by_username[storage_credential.username]    = [
-                                                                               storage_credential['id'],
-                                                                               storage_credential.username,
-                                                                               storage_credential.password,
-                                                                               storage_credentials[:type].to_s
-                                                                              ]
+            if options[:show_password]
+              storage_credentials_by_username[storage_credential.username] = [
+                                                                              storage_credential['id'],
+                                                                              storage_credential.username,
+                                                                              storage_credential.password,
+                                                                              storage_credentials[:type].to_s
+                                                                             ]
+            else
+              storage_credentials_by_username[storage_credential.username] = [
+                                                                              storage_credential['id'],
+                                                                              storage_credential.username,
+                                                                              storage_credentials[:type].to_s
+                                                                             ]
+            end
           end
         end
 
@@ -1258,6 +1306,7 @@ class VagrantSoftLayerCredentials
                  [ '--manufacturer',    '-m', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--name',            '-n', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--password',        '-p', GetoptLong::NO_ARGUMENT       ],
+                 [ '--show_password',   '-s', GetoptLong::NO_ARGUMENT       ],
                  [ '--sl_api_key',      '-k', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--sl_endpoint_url', '-e', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--sl_timeout',      '-t', GetoptLong::REQUIRED_ARGUMENT ],
@@ -1282,6 +1331,7 @@ class VagrantSoftLayerCredentials
       :lost_password_key => nil,
       :password          => nil,
       :password_flag     => false,
+      :show_password     => false,
       :sl_credentials    => {
         :api_key      => nil,
         :endpoint_url => SoftLayer::API_PUBLIC_ENDPOINT,
@@ -1478,6 +1528,9 @@ Usage: #{File.basename($0)} app_delivery_controller list [options]
 
 List Credential Options:
 
+--show_password|-s:
+    List the password for application delivery controller credential(s) username(s).
+
 --username|-u <USERNAME>,...:
     List the application delivery controller credential(s) for these username(s) only.
 
@@ -1515,6 +1568,9 @@ HELP_APP_DELIV_CONTROL_SET
 Usage: #{File.basename($0)} network_message_delivery list [options]
 
 List Credential Options:
+
+--show_password|-s:
+    List the password for network message delivery credential(s) username(s).
 
 --username|-u <USERNAME>,...:
     List the network message delivery credential(s) for these username(s) only.
@@ -1555,6 +1611,9 @@ HELP_NMD_SET
 Usage: #{File.basename($0)} network_vlan_firewall list [options]
 
 List Credential Options:
+
+--show_password|-s:
+    List the password for network VLAN firewall credential(s) username(s).
 
 --username|-u <USERNAME>,...:
     List the network VLAN firewall credential(s) for these username(s) only.
@@ -1609,6 +1668,9 @@ Usage: #{File.basename($0)} software list [options]
 
 List Credential Options:
 
+--show_password|-s:
+    List the password for software credential(s) username(s).
+
 --username|-u <USERNAME>,...:
     List the software credential(s) for these username(s) only.
 
@@ -1623,6 +1685,11 @@ HELP_SW_LIST
 Usage: #{File.basename($0)} software list-details [options] <ID>...
 
 <ID> - One or more software credential ID's to list details for
+
+List Credential Options:
+
+--show_password|-s:
+    List the password for software credential(s) username(s).
 
 #{@help[:std_opts]}
 HELP_SW_LIST_DETAILS
@@ -1659,6 +1726,9 @@ HELP_SW_SET_PW
 Usage: #{File.basename($0)} storage list [options]
 
 List Credential Options:
+
+--show_password|-s:
+    List the password for network storage credential(s) username(s).
 
 --username|-u <USERNAME>,...:
     List the network storage credential(s) for these username(s) only.
@@ -1810,8 +1880,9 @@ HELP_USER_SET_SEC_ANS
           list_filter[:username] = @config[:username] unless @config[:username].empty?
 
           exit 1 unless SoftLayer::Managers::Credentials.list_app_delivery_controller_credentials(@softlayer_client,
-                                                                                                  :filters    => list_filter,
-                                                                                                  :yes_prompt => @config[:yes_prompt])
+                                                                                                  :filters       => list_filter,
+                                                                                                  :show_password => @config[:show_password],
+                                                                                                  :yes_prompt    => @config[:yes_prompt])
 
         when :set
           set_filter            = @config[:filters]
@@ -1831,8 +1902,9 @@ HELP_USER_SET_SEC_ANS
           list_filter[:username] = @config[:username] unless @config[:username].empty?
 
           exit 1 unless SoftLayer::Managers::Credentials.list_network_message_delivery_credentials(@softlayer_client,
-                                                                                                   :filters    => list_filter,
-                                                                                                   :yes_prompt => @config[:yes_prompt])
+                                                                                                   :filters       => list_filter,
+                                                                                                   :show_password => @config[:show_password],
+                                                                                                   :yes_prompt    => @config[:yes_prompt])
 
         when :set
           set_filter            = @config[:filters]
@@ -1852,8 +1924,9 @@ HELP_USER_SET_SEC_ANS
           list_filter[:username] = @config[:username] unless @config[:username].empty?
 
           exit 1 unless SoftLayer::Managers::Credentials.list_network_vlan_firewall_credentials(@softlayer_client,
-                                                                                                :filters    => list_filter,
-                                                                                                :yes_prompt => @config[:yes_prompt])
+                                                                                                :filters       => list_filter,
+                                                                                                :show_password => @config[:show_password],
+                                                                                                :yes_prompt    => @config[:yes_prompt])
 
         when :set
           set_filter            = @config[:filters]
@@ -1878,11 +1951,14 @@ HELP_USER_SET_SEC_ANS
           list_filter[:username] = @config[:username] unless @config[:username].empty?
 
           exit 1 unless SoftLayer::Managers::Credentials.list_software_credentials(@softlayer_client,
-                                                                                   :filters    => list_filter,
-                                                                                   :yes_prompt => @config[:yes_prompt])
+                                                                                   :filters       => list_filter,
+                                                                                   :show_password => @config[:show_password],
+                                                                                   :yes_prompt    => @config[:yes_prompt])
 
         when :"list-details"
-          exit 1 unless SoftLayer::Managers::Credentials.list_software_credential_details(@softlayer_client, @config[:filters][:credentials])
+          exit 1 unless SoftLayer::Managers::Credentials.list_software_credential_details(@softlayer_client,
+                                                                                          @config[:filters][:credentials],
+                                                                                          :show_password => @config[:show_password])
 
         when :set
           set_filter            = @config[:filters]
@@ -1903,8 +1979,9 @@ HELP_USER_SET_SEC_ANS
           list_filter[:username] = @config[:username] unless @config[:username].empty?
 
           exit 1 unless SoftLayer::Managers::Credentials.list_storage_credentials(@softlayer_client,
-                                                                                  :filters    => list_filter,
-                                                                                  :yes_prompt => @config[:yes_prompt])
+                                                                                  :filters       => list_filter,
+                                                                                  :show_password => @config[:show_password],
+                                                                                  :yes_prompt    => @config[:yes_prompt])
 
         when :set
           set_filter            = @config[:filters]
@@ -2322,6 +2399,9 @@ HELP_USER_SET_SEC_ANS
 
         when '--password'
           @config[:password_flag] = true
+
+        when '--show_password'
+          @config[:show_password] = true
 
         when '--sl_api_key'
           @config[:sl_credentials][:api_key] = optval.to_s

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -5,315 +5,322 @@ require 'getoptlong'
 require 'rubygems'
 require 'softlayer_api'
 
-class SoftLayerCredentialManager
-  def self.delete_software_credentials(softlayer_client, software_password_ids, options = {})
-    raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-    raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+module SoftLayer
+  class SoftLayerCredentialManager
+    def self.delete_software_credentials(softlayer_client, software_password_ids, options = {})
+      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-    if ! options[:yes_prompt]
-      exit 0 unless yes_prompt("You are deleting one or more software credentials, this cannot be undone, continue?")
+      if ! options[:yes_prompt]
+        return false unless yes_prompt("You are deleting one or more software credentials, this cannot be undone, continue?")
+      end
+
+      software_password_service = softlayer_client[:Software_Component_Password]
+      software_password_service.deleteObjects(software_password_ids.map { |sw_pw_id| { 'id' => sw_pw_id } })
+
+      return true
     end
 
-    software_password_service = softlayer_client[:Software_Component_Password]
-    software_password_service.deleteObjects(software_password_ids.map { |sw_pw_id| { 'id' => sw_pw_id } })
-  end
+    def self.list_software_credential_details(softlayer_client, software_password_ids)
+      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-  def self.list_software_credential_details(softlayer_client, software_password_ids)
-    raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-    raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+      software_password_ids.each do |sw_pw_id|
+        software_password_details = [ [ 'Name', 'Value' ] ]
 
-    software_password_ids.each do |sw_pw_id|
-      software_password_details = [ [ 'Name', 'Value' ] ]
+        software_password_service = softlayer_client[:Software_Component_Password].object_with_id(sw_pw_id)
+        software_password_service = software_password_service.object_mask(software_password_mask(:"list-details"))
 
-      software_password_service = softlayer_client[:Software_Component_Password].object_with_id(sw_pw_id)
-      software_password_service = software_password_service.object_mask(software_password_mask(:"list-details"))
+        software_password         = software_password_service.getObject
+        server_type               = software_password['software'].has_key?('hardware') ? 'hardware' : 'virtualGuest'
+        required_user             = software_password['username'] == software_password['software']['softwareDescription']['requiredUser'] ? 'YES' : 'NO'
 
-      software_password         = software_password_service.getObject
-      server_type               = software_password['software'].has_key?('hardware') ? 'hardware' : 'virtualGuest'
-      required_user             = software_password['username'] == software_password['software']['softwareDescription']['requiredUser'] ? 'YES' : 'NO'
+        software_password_details.push([ 'id',            software_password['id'].to_s ])
+        software_password_details.push([ 'username',      software_password['username'] ])
+        software_password_details.push([ 'password',      software_password['password'] ])
+        software_password_details.push([ 'last modified', software_password['modifyDate'] ])
+        software_password_details.push([ 'port',          software_password['port'] || "" ])
+        software_password_details.push([ 'notes',         software_password['notes'] || "" ])
+        software_password_details.push([ 'required user', required_user ])
+        software_password_details.push([ 'description',   software_password['software']['softwareDescription']['longDescription'] ])
+        software_password_details.push([ 'name',          software_password['software']['softwareDescription']['name'] ])
+        software_password_details.push([ 'manufacturer',  software_password['software']['softwareDescription']['manufacturer'] ])
+        software_password_details.push([ 'hostname',      software_password['software'][server_type]['hostname'] ])
+        software_password_details.push([ 'domain',        software_password['software'][server_type]['domain'] ])
+        software_password_details.push([ 'datacenter',    software_password['software'][server_type]['datacenter']['name'] ])
+        software_password_details.push([ 'server type',   software_password['software'].has_key?('hardware') ? 'Hardware' : 'Virtual Guest' ])
+        software_password_details.push([ 'tags',          software_password['software'][server_type]['tagReferences'].collect { |tag| tag['tag']['name'] }.join(", ") ])
 
-      software_password_details.push([ 'id',            software_password['id'].to_s ])
-      software_password_details.push([ 'username',      software_password['username'] ])
-      software_password_details.push([ 'password',      software_password['password'] ])
-      software_password_details.push([ 'last modified', software_password['modifyDate'] ])
-      software_password_details.push([ 'port',          software_password['port'] || "" ])
-      software_password_details.push([ 'notes',         software_password['notes'] || "" ])
-      software_password_details.push([ 'required user', required_user ])
-      software_password_details.push([ 'description',   software_password['software']['softwareDescription']['longDescription'] ])
-      software_password_details.push([ 'name',          software_password['software']['softwareDescription']['name'] ])
-      software_password_details.push([ 'manufacturer',  software_password['software']['softwareDescription']['manufacturer'] ])
-      software_password_details.push([ 'hostname',      software_password['software'][server_type]['hostname'] ])
-      software_password_details.push([ 'domain',        software_password['software'][server_type]['domain'] ])
-      software_password_details.push([ 'datacenter',    software_password['software'][server_type]['datacenter']['name'] ])
-      software_password_details.push([ 'server type',   software_password['software'].has_key?('hardware') ? 'Hardware' : 'Virtual Guest' ])
-      software_password_details.push([ 'tags',          software_password['software'][server_type]['tagReferences'].collect { |tag| tag['tag']['name'] }.join(", ") ])
-      
-      pretty_print_table(software_password_details)
-      puts if software_password_ids.length > 1
-    end
-  end
-
-  def self.list_software_credentials(softlayer_client, options = {})
-    raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-    raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
-
-    if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
-      exit 0 unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
+        pretty_print_table(software_password_details)
+        puts if software_password_ids.length > 1
+      end
     end
 
-    software_passwords = get_software_passwords(softlayer_client, options)
+    def self.list_software_credentials(softlayer_client, options = {})
+      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
-    software_passwords.map! { |sw_pw| [ sw_pw['id'].to_s, sw_pw['software']['softwareDescription']['name'], sw_pw.username, sw_pw.password ] }
-    software_passwords.sort_by! { |element| element[1] }
-    software_passwords.unshift([ "id", "software name", "username", "password" ])
+      if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+        return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
+      end
 
-    pretty_print_table(software_passwords)
-  end
+      software_passwords = get_software_passwords(softlayer_client, options)
 
-  def self.set_software_credentials(softlayer_client, password, options = {})
-    raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-    raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+      software_passwords.map! { |sw_pw| [ sw_pw['id'].to_s, sw_pw['software']['softwareDescription']['name'], sw_pw.username, sw_pw.password ] }
+      software_passwords.sort_by! { |element| element[1] }
+      software_passwords.unshift([ "id", "software name", "username", "password" ])
 
-    if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
-      exit 0 unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
+      pretty_print_table(software_passwords)
+
+      return true
     end
 
-    if ! options[:yes_prompt]
-      exit 0 unless yes_prompt("You are setting one or more software credentials, this cannot be undone, continue?")
+    def self.set_software_credentials(softlayer_client, password, options = {})
+      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+      if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+        return false unless yes_prompt("No filter options have been specified to narrow credential list to update, it may take a while to process, continue?")
+      end
+
+      if ! options[:yes_prompt]
+        return false unless yes_prompt("You are setting one or more software credentials, this cannot be undone, continue?")
+      end
+
+      software_passwords = get_software_passwords(softlayer_client, options)
+
+      SoftLayer::SoftwarePassword.update_passwords(software_passwords, password, :client => softlayer_client)
+
+      if options[:add_user_password]
+        add_software_credentials(softlayer_client, password, options)
+      end
+
+      return true
     end
 
-    software_passwords = get_software_passwords(softlayer_client, options)
+    private
 
-    SoftLayer::SoftwarePassword.update_passwords(software_passwords, password, :client => softlayer_client)
+    def self.add_software_credentials(softlayer_client, password, options = {})
+      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+      raise "Expected a list of usernames to add software credentials for as part of filters" if ! options[:filter] || ! options[:filter][:username] || options[:filter][:username].empty?
 
-     if options[:add_user_password]
-      add_software_credentials(softlayer_client, password, options)
-    end
-  end
-  
-  private
+      hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
 
-  def self.add_software_credentials(softlayer_client, password, options = {})
-    raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-    raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
-    raise "Expected a list of usernames to add software credentials for as part of filters" if ! options[:filter] || ! options[:filter][:username] || options[:filter][:username].empty?
+      add_hardware_passwords       = true
+      add_virtual_server_passwords = true
 
-    hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
-    
-    add_hardware_passwords       = true
-    add_virtual_server_passwords = true
+      add_hardware_passwords       = false if options[:filter] && options[:filter][:virtual_servers_only]
+      add_virtual_server_passwords = false if options[:filter] && options[:filter][:hardware_only]
 
-    add_hardware_passwords       = false if options[:filter] && options[:filter][:virtual_servers_only]
-    add_virtual_server_passwords = false if options[:filter] && options[:filter][:hardware_only]
+      if add_hardware_passwords && (options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?)
+        hardware_types             = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
+      end
 
-    if add_hardware_passwords && (options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?)
-      hardware_types             = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
-    end
+      object_filters               = software_password_filters(:add, options)
 
-    object_filters               = software_password_filters(:add, options)
+      software                     = []
 
-    software                     = []
+      if add_hardware_passwords
+        hardware_types.each do |hardware_type|
+          software_data = SoftLayer::Software.find_software_on_hardware(:client                 => softlayer_client,
+                                                                        :hardware_object_filter => object_filters[:hardware][hardware_type],
+                                                                        :software_object_filter => object_filters[:software],
+                                                                        :software_object_mask   => software_mask)
 
-    if add_hardware_passwords
-      hardware_types.each do |hardware_type|
-        software_data = SoftLayer::Software.find_software_on_hardware(:client                 => softlayer_client,
-                                                                      :hardware_object_filter => object_filters[:hardware][hardware_type],
-                                                                      :software_object_filter => object_filters[:software],
-                                                                      :software_object_mask   => software_mask)
+          software.concat(software_data)
+        end
+      end
+
+      if add_virtual_server_passwords
+        software_data = SoftLayer::Software.find_software_on_virtual_servers(:client                       => softlayer_client,
+                                                                             :software_object_filter       => object_filters[:software],
+                                                                             :software_object_mask         => software_mask,
+                                                                             :virtual_server_object_filter => object_filters[:virtual_server])
 
         software.concat(software_data)
       end
-    end
 
-    if add_virtual_server_passwords
-      software_data = SoftLayer::Software.find_software_on_virtual_servers(:client                       => softlayer_client,
-                                                                           :software_object_filter       => object_filters[:software],
-                                                                           :software_object_mask         => software_mask,
-                                                                           :virtual_server_object_filter => object_filters[:virtual_server])
-
-      software.concat(software_data)
-    end
-    
-    software_passwords_template = software.map do |sw|
-      options[:filter][:username].collect do |username|
-        { 'softwareId' => sw['id'], 'password' => password.to_s, 'username' => username } if sw['passwords'] && ! sw['passwords'].map{ |pw| pw['username'] }.include?(username)
-      end
-    end
-
-    software_password_service = softlayer_client[:Software_Component_Password]
-    software_password_service.createObjects(software_passwords_template.flatten.compact)
-  end
-
-  def self.get_software_passwords(softlayer_client, options = {})
-    raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
-    raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
-
-    hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
-    
-    list_hardware_passwords       = true
-    list_virtual_server_passwords = true
-
-    list_hardware_passwords       = false if options[:filter] && options[:filter][:virtual_servers_only]
-    list_virtual_server_passwords = false if options[:filter] && options[:filter][:hardware_only]
-
-    if list_hardware_passwords && (options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?)
-      hardware_types              = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
-    end
-
-    object_filters                = software_password_filters(:list, options)
-    
-    software_passwords            = []
-
-    if list_hardware_passwords
-      hardware_types.each do |hardware_type|
-        passwords = SoftLayer::SoftwarePassword.find_passwords_for_software_on_hardware(:client                          => softlayer_client,
-                                                                                        :hardware_object_filter          => object_filters[:hardware][hardware_type],
-                                                                                        :software_object_filter          => object_filters[:software],
-                                                                                        :software_password_object_filter => object_filters[:software_password],
-                                                                                        :software_password_object_mask   => software_password_mask(:list))
-        software_passwords.concat(passwords)
-      end
-    end
-
-    if list_virtual_server_passwords
-      passwords = SoftLayer::SoftwarePassword.find_passwords_for_software_on_virtual_servers(:client                          => softlayer_client,
-                                                                                             :software_object_filter          => object_filters[:software],
-                                                                                             :software_password_object_filter => object_filters[:software_password],
-                                                                                             :software_password_object_mask   => software_password_mask(:list),
-                                                                                             :virtual_server_object_filter    => object_filters[:virtual_server])
-      software_passwords.concat(passwords)
-    end
-
-    return software_passwords
-  end
-
-  def self.pretty_print_table(table)
-    max_col_widths = table.transpose.map { |col| col.group_by(&:size).max.first + 2 }
-    print ':' + max_col_widths.map { |col_width| '.' * col_width}.join(':' ) + ":\n:"
-    table[0].each_index {|col| print table[0][col].center(max_col_widths[col]) + ':' }
-    print "\n:" + max_col_widths.map { |col_width| '.' * col_width }.join(':') + ":\n"
-    table.shift
-    table.each do |row|
-      print ':'
-      row.each_index { |col| print row[col].center(max_col_widths[col]) + ':' }
-      puts
-    end
-    puts ':' + max_col_widths.map { |col_width| '.' * col_width }.join(':') + ':'
-  end
-  
-  def self.software_mask()
-    {
-      "mask(SoftLayer_Software_Component)" => [
-                                               'id',
-                                               'manufacturerActivationCode',
-                                               'manufacturerLicenseInstance',
-                                               'passwords.username'
-                                              ]
-    }.to_sl_object_mask
-  end
-
-  def self.software_password_filters(filter_type, options = {})
-    filter_label = {
-      :bare_metal_instance => "bareMetalInstances",
-      :hardware            => "hardware",
-      :network_hardware    => "networkHardware",
-      :router              => "routers"
-    }
-
-    hardware_types                  = filter_label.keys
-
-    list_hardware_passwords         = true
-    list_virtual_server_passwords   = true
-
-    hardware_object_filter          = {
-      :bare_metal_instance          => SoftLayer::ObjectFilter.new(),
-      :hardware                     => SoftLayer::ObjectFilter.new(),
-      :network_hardware             => SoftLayer::ObjectFilter.new(),
-      :router                       => SoftLayer::ObjectFilter.new()
-    }
-    software_object_filter          = SoftLayer::ObjectFilter.new()
-    software_password_object_filter = SoftLayer::ObjectFilter.new()
-    virtual_server_object_filter    = SoftLayer::ObjectFilter.new()
-
-    option_to_filter_path = {
-      :hardware          => {
-        :datacenter      => lambda { |hardware_type| return [ filter_label[hardware_type], '.datacenter.name' ].join        },
-        :domain          => lambda { |hardware_type| return [ filter_label[hardware_type], '.domain' ].join                 },
-        :hostname        => lambda { |hardware_type| return [ filter_label[hardware_type], '.hostname' ].join               },
-        :tag             => lambda { |hardware_type| return [ filter_label[hardware_type], '.tagReferences.tag.name' ].join }
-      },
-      :software          => {
-        :description     => "softwareComponents.softwareDescription.longDescription",
-        :manufacturer    => "softwareComponents.softwareDescription.manufacturer",
-        :name            => "softwareComponents.softwareDescription.name",
-        :username        => "softwareComponents.passwords.username"
-      },
-      :software_password => {
-        :username        => "passwords.username"
-      },
-      :virtual_server    => {
-        :datacenter      => "virtualGuests.datacenter.name",
-        :domain          => "virtualGuests.domain",
-        :hostname        => "virtualGuests.hostname",
-        :tag             => "virtualGuests.tagReferences.tag.name"
-      }
-    }
-
-    if options[:filter]
-      list_hardware_passwords       = false if options[:filter][:virtual_servers_only]
-      list_virtual_server_passwords = false if options[:filter][:hardware_only]
-
-      option_to_filter_path[:software].each do |option, filter_path|
-        if options[:filter][option] && ! options[:filter][option].empty?
-          next if option == :username && filter_type == :add
-
-          software_object_filter.set_criteria_for_key_path(filter_path,
-                                                           {
-                                                             'operation' => 'in',
-                                                             'options' => [{
-                                                                             'name' => 'data',
-                                                                             'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
-                                                                           }]
-                                                           })
+      software_passwords_template = software.map do |sw|
+        options[:filter][:username].collect do |username|
+          { 'softwareId' => sw['id'], 'password' => password.to_s, 'username' => username } if sw['passwords'] && ! sw['passwords'].map{ |pw| pw['username'] }.include?(username)
         end
       end
 
-      option_to_filter_path[:software_password].each do |option, filter_path|
-        if options[:filter][option] && ! options[:filter][option].empty?
-          software_password_object_filter.set_criteria_for_key_path(filter_path,
-                                                                    {
-                                                                      'operation' => 'in',
-                                                                      'options' => [{
-                                                                                      'name' => 'data',
-                                                                                      'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
-                                                                                    }]
-                                                                    })
-        end
+      software_password_service = softlayer_client[:Software_Component_Password]
+      software_password_service.createObjects(software_passwords_template.flatten.compact)
+    end
+
+    def self.get_software_passwords(softlayer_client, options = {})
+      raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+      raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+      hardware_types                = [ :bare_metal_instance, :hardware, :network_hardware, :router ]
+
+      list_hardware_passwords       = true
+      list_virtual_server_passwords = true
+
+      list_hardware_passwords       = false if options[:filter] && options[:filter][:virtual_servers_only]
+      list_virtual_server_passwords = false if options[:filter] && options[:filter][:hardware_only]
+
+      if list_hardware_passwords && (options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?)
+        hardware_types              = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
       end
+
+      object_filters                = software_password_filters(:list, options)
+
+      software_passwords            = []
 
       if list_hardware_passwords
-        if options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?
-          hardware_types = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
-        end
-        
         hardware_types.each do |hardware_type|
-          option_to_filter_path[:hardware].each do |option, filter_path|
-            if options[:filter][option] && ! options[:filter][option].empty?
-              hardware_object_filter[hardware_type].set_criteria_for_key_path(filter_path.call(hardware_type),
-                                                                              {
-                                                                                'operation' => 'in',
-                                                                                'options' => [{
-                                                                                                'name' => 'data',
-                                                                                                'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
-                                                                                              }]
-                                                                              })
-            end
-          end
+          passwords = SoftLayer::SoftwarePassword.find_passwords_for_software_on_hardware(:client                          => softlayer_client,
+                                                                                          :hardware_object_filter          => object_filters[:hardware][hardware_type],
+                                                                                          :software_object_filter          => object_filters[:software],
+                                                                                          :software_password_object_filter => object_filters[:software_password],
+                                                                                          :software_password_object_mask   => software_password_mask(:list))
+          software_passwords.concat(passwords)
         end
       end
 
       if list_virtual_server_passwords
-        option_to_filter_path[:virtual_server].each do |option, filter_path|
+        passwords = SoftLayer::SoftwarePassword.find_passwords_for_software_on_virtual_servers(:client                          => softlayer_client,
+                                                                                               :software_object_filter          => object_filters[:software],
+                                                                                               :software_password_object_filter => object_filters[:software_password],
+                                                                                               :software_password_object_mask   => software_password_mask(:list),
+                                                                                               :virtual_server_object_filter    => object_filters[:virtual_server])
+        software_passwords.concat(passwords)
+      end
+
+      return software_passwords
+    end
+
+    def self.pretty_print_table(table)
+      max_col_widths = table.transpose.map { |col| col.group_by(&:size).max.first + 2 }
+      print ':' + max_col_widths.map { |col_width| '.' * col_width}.join(':' ) + ":\n:"
+      table[0].each_index {|col| print table[0][col].center(max_col_widths[col]) + ':' }
+      print "\n:" + max_col_widths.map { |col_width| '.' * col_width }.join(':') + ":\n"
+      table.shift
+      table.each do |row|
+        print ':'
+        row.each_index { |col| print row[col].center(max_col_widths[col]) + ':' }
+        puts
+      end
+      puts ':' + max_col_widths.map { |col_width| '.' * col_width }.join(':') + ':'
+    end
+
+    def self.software_mask()
+      {
+        "mask(SoftLayer_Software_Component)" => [
+                                                 'id',
+                                                 'manufacturerActivationCode',
+                                                 'manufacturerLicenseInstance',
+                                                 'passwords.username'
+                                                ]
+      }.to_sl_object_mask
+    end
+
+    def self.software_password_filters(filter_type, options = {})
+      filter_label = {
+        :bare_metal_instance => "bareMetalInstances",
+        :hardware            => "hardware",
+        :network_hardware    => "networkHardware",
+        :router              => "routers"
+      }
+
+      hardware_types                  = filter_label.keys
+
+      list_hardware_passwords         = true
+      list_virtual_server_passwords   = true
+
+      hardware_object_filter          = {
+        :bare_metal_instance          => SoftLayer::ObjectFilter.new(),
+        :hardware                     => SoftLayer::ObjectFilter.new(),
+        :network_hardware             => SoftLayer::ObjectFilter.new(),
+        :router                       => SoftLayer::ObjectFilter.new()
+      }
+      software_object_filter          = SoftLayer::ObjectFilter.new()
+      software_password_object_filter = SoftLayer::ObjectFilter.new()
+      virtual_server_object_filter    = SoftLayer::ObjectFilter.new()
+
+      option_to_filter_path = {
+        :hardware          => {
+          :datacenter      => lambda { |hardware_type| return [ filter_label[hardware_type], '.datacenter.name' ].join        },
+          :domain          => lambda { |hardware_type| return [ filter_label[hardware_type], '.domain' ].join                 },
+          :hostname        => lambda { |hardware_type| return [ filter_label[hardware_type], '.hostname' ].join               },
+          :tag             => lambda { |hardware_type| return [ filter_label[hardware_type], '.tagReferences.tag.name' ].join }
+        },
+        :software          => {
+          :description     => "softwareComponents.softwareDescription.longDescription",
+          :manufacturer    => "softwareComponents.softwareDescription.manufacturer",
+          :name            => "softwareComponents.softwareDescription.name",
+          :username        => "softwareComponents.passwords.username"
+        },
+        :software_password => {
+          :username        => "passwords.username"
+        },
+        :virtual_server    => {
+          :datacenter      => "virtualGuests.datacenter.name",
+          :domain          => "virtualGuests.domain",
+          :hostname        => "virtualGuests.hostname",
+          :tag             => "virtualGuests.tagReferences.tag.name"
+        }
+      }
+
+      if options[:filter]
+        list_hardware_passwords       = false if options[:filter][:virtual_servers_only]
+        list_virtual_server_passwords = false if options[:filter][:hardware_only]
+
+        option_to_filter_path[:software].each do |option, filter_path|
+          if options[:filter][option] && ! options[:filter][option].empty?
+            next if option == :username && filter_type == :add
+
+            software_object_filter.set_criteria_for_key_path(filter_path,
+                                                             {
+                                                               'operation' => 'in',
+                                                               'options' => [{
+                                                                               'name' => 'data',
+                                                                               'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                             }]
+                                                             })
+          end
+        end
+
+        option_to_filter_path[:software_password].each do |option, filter_path|
+          if options[:filter][option] && ! options[:filter][option].empty?
+            software_password_object_filter.set_criteria_for_key_path(filter_path,
+                                                                      {
+                                                                        'operation' => 'in',
+                                                                        'options' => [{
+                                                                                        'name' => 'data',
+                                                                                        'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                                      }]
+                                                                      })
+          end
+        end
+
+        if list_hardware_passwords
+          if options[:filter][:hardware_type] && ! options[:filter][:hardware_type].empty?
+            hardware_types = options[:filter][:hardware_type].map { |hardware_type| hardware_type.to_sym }
+          end
+
+          hardware_types.each do |hardware_type|
+            option_to_filter_path[:hardware].each do |option, filter_path|
+              if options[:filter][option] && ! options[:filter][option].empty?
+                hardware_object_filter[hardware_type].set_criteria_for_key_path(filter_path.call(hardware_type),
+                                                                                {
+                                                                                  'operation' => 'in',
+                                                                                  'options' => [{
+                                                                                                  'name' => 'data',
+                                                                                                  'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                                                }]
+                                                                                })
+              end
+            end
+          end
+        end
+
+        if list_virtual_server_passwords
+          option_to_filter_path[:virtual_server].each do |option, filter_path|
             if options[:filter][option] && ! options[:filter][option].empty?
               virtual_server_object_filter.set_criteria_for_key_path(filter_path,
                                                                      {
@@ -324,65 +331,66 @@ class SoftLayerCredentialManager
                                                                                      }]
                                                                      })
             end
+          end
+        end
+      end
+
+      {
+        :hardware          => hardware_object_filter,
+        :software          => software_object_filter,
+        :software_password => software_password_object_filter,
+        :virtual_server    => virtual_server_object_filter
+      }
+    end
+
+    def self.software_password_mask(mask_type)
+      case mask_type
+      when :list
+        {
+          "mask(SoftLayer_Software_Component_Password)" => [
+                                                            'createDate',
+                                                            'id',
+                                                            'modifyDate',
+                                                            'notes',
+                                                            'password',
+                                                            'port',
+                                                            'software.softwareDescription.name',
+                                                            'username'
+                                                           ]
+        }.to_sl_object_mask
+      when :"list-details"
+        {
+          "mask(SoftLayer_Software_Component_Password)" => [
+                                                            'id',
+                                                            'modifyDate',
+                                                            'notes',
+                                                            'password',
+                                                            'port',
+                                                            'software.hardware[datacenter.name, domain, hostname, tagReferences.tag.name]',
+                                                            'software.softwareDescription[longDescription, manufacturer, name, requiredUser]',
+                                                            'software.virtualGuest[datacenter.name, domain, hostname, tagReferences.tag.name]',
+                                                            'username'
+                                                           ]
+        }.to_sl_object_mask
+      end
+    end
+
+    def self.yes_prompt(prompt_message)
+      while true do
+        $stderr.print prompt_message.to_s + " (Y/N): "
+
+        case $stdin.readline().chomp!
+        when 'yes', 'y', 'Y'
+          return true
+        when 'no', 'n', 'N'
+          return false
+        else
+          next
         end
       end
     end
-
-    { 
-      :hardware          => hardware_object_filter,
-      :software          => software_object_filter,
-      :software_password => software_password_object_filter,
-      :virtual_server    => virtual_server_object_filter
-    }
-  end
-
-  def self.software_password_mask(mask_type)
-    case mask_type
-    when :list
-      {
-        "mask(SoftLayer_Software_Component_Password)" => [
-                                                          'createDate',
-                                                          'id',
-                                                          'modifyDate',
-                                                          'notes',
-                                                          'password',
-                                                          'port',
-                                                          'software.softwareDescription.name',
-                                                          'username'
-                                                         ]
-      }.to_sl_object_mask
-    when :"list-details"
-      {
-        "mask(SoftLayer_Software_Component_Password)" => [
-                                                          'id',
-                                                          'modifyDate',
-                                                          'notes',
-                                                          'password',
-                                                          'port',
-                                                          'software.hardware[datacenter.name, domain, hostname, tagReferences.tag.name]',
-                                                          'software.softwareDescription[longDescription, manufacturer, name, requiredUser]',
-                                                          'software.virtualGuest[datacenter.name, domain, hostname, tagReferences.tag.name]',
-                                                          'username'
-                                                         ]
-      }.to_sl_object_mask
-    end
-  end
-
-  def self.yes_prompt(prompt_message)
-    while true do
-      $stderr.print prompt_message.to_s + " (Y/N): "
-      
-      case $stdin.readline().chomp!
-      when 'yes', 'y', 'Y'
-        return true
-      when 'no', 'n', 'N'
-        return false
-      else
-        next        
-      end
-    end
-  end
-end #SoftLayerCredentialManager
+  end #SoftLayerCredentialManager
+end
 
 class VagrantSoftLayerCredentials
   def initialize()
@@ -584,17 +592,17 @@ HELP_SW_SET_PW
     when :software
       case @config[:action]
       when :delete
-        SoftLayerCredentialManager.delete_software_credentials(softlayer_client,
-                                                               @config[:action_args],
-                                                               :yes_prompt => @config[:yes_prompt])
+        exit 0 unless SoftLayer::SoftLayerCredentialManager.delete_software_credentials(softlayer_client,
+                                                                                        @config[:action_args],
+                                                                                        :yes_prompt => @config[:yes_prompt])
 
       when :list
         list_filter            = @config[:filters]
         list_filter[:username] = @config[:username] unless @config[:username].empty?
 
-        SoftLayerCredentialManager.list_software_credentials(softlayer_client,
-                                                             :filter     => list_filter,
-                                                             :yes_prompt => @config[:yes_prompt])
+        exit 0 unless SoftLayer::SoftLayerCredentialManager.list_software_credentials(softlayer_client,
+                                                                                      :filter     => list_filter,
+                                                                                      :yes_prompt => @config[:yes_prompt])
 
       when :"list-details"
         SoftLayerCredentialManager.list_software_credential_details(softlayer_client, @config[:action_args])
@@ -603,11 +611,11 @@ HELP_SW_SET_PW
         set_filter            = @config[:filters]
         set_filter[:username] = @config[:username] unless @config[:username].empty?
 
-        SoftLayerCredentialManager.set_software_credentials(softlayer_client,
-                                                            @config[:password],
-                                                            :add_user_password => @config[:add_user_password],
-                                                            :filter            => @config[:filters],
-                                                            :yes_prompt        => @config[:yes_prompt])
+        exit 0 unless SoftLayer::SoftLayerCredentialManager.set_software_credentials(softlayer_client,
+                                                                                     @config[:password],
+                                                                                     :add_user_password => @config[:add_user_password],
+                                                                                     :filter            => @config[:filters],
+                                                                                     :yes_prompt        => @config[:yes_prompt])
 
       end
     end

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -6,7 +6,7 @@ require 'rubygems'
 require 'softlayer_api'
 
 module SoftLayer
-  class SoftLayerCredentialManager
+  class CredentialManager
     def self.delete_software_credentials(softlayer_client, software_password_ids, options = {})
       raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
       raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
@@ -26,7 +26,7 @@ module SoftLayer
       raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
 
       software_password_ids.each do |sw_pw_id|
-        software_password_details = [ [ 'Name', 'Value' ] ]
+        software_password_details = [ [ 'name', 'value' ] ]
 
         software_password_service = softlayer_client[:Software_Component_Password].object_with_id(sw_pw_id)
         software_password_service = software_password_service.object_mask(software_password_mask(:"list-details"))
@@ -279,7 +279,7 @@ module SoftLayer
                                                                'operation' => 'in',
                                                                'options' => [{
                                                                                'name' => 'data',
-                                                                               'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                               'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
                                                                              }]
                                                              })
           end
@@ -292,7 +292,7 @@ module SoftLayer
                                                                         'operation' => 'in',
                                                                         'options' => [{
                                                                                         'name' => 'data',
-                                                                                        'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                                        'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
                                                                                       }]
                                                                       })
           end
@@ -311,7 +311,7 @@ module SoftLayer
                                                                                   'operation' => 'in',
                                                                                   'options' => [{
                                                                                                   'name' => 'data',
-                                                                                                  'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                                                  'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
                                                                                                 }]
                                                                                 })
               end
@@ -327,7 +327,7 @@ module SoftLayer
                                                                        'operation' => 'in',
                                                                        'options' => [{
                                                                                        'name' => 'data',
-                                                                                       'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
+                                                                                       'value' => options[:filter][option].collect{ |filter_value| filter_value.to_s }
                                                                                      }]
                                                                      })
             end
@@ -389,7 +389,7 @@ module SoftLayer
         end
       end
     end
-  end #SoftLayerCredentialManager
+  end #CredentialManager
 end
 
 class VagrantSoftLayerCredentials
@@ -592,30 +592,30 @@ HELP_SW_SET_PW
     when :software
       case @config[:action]
       when :delete
-        exit 0 unless SoftLayer::SoftLayerCredentialManager.delete_software_credentials(softlayer_client,
-                                                                                        @config[:action_args],
-                                                                                        :yes_prompt => @config[:yes_prompt])
+        exit 0 unless SoftLayer::CredentialManager.delete_software_credentials(softlayer_client,
+                                                                               @config[:action_args],
+                                                                               :yes_prompt => @config[:yes_prompt])
 
       when :list
         list_filter            = @config[:filters]
         list_filter[:username] = @config[:username] unless @config[:username].empty?
 
-        exit 0 unless SoftLayer::SoftLayerCredentialManager.list_software_credentials(softlayer_client,
-                                                                                      :filter     => list_filter,
-                                                                                      :yes_prompt => @config[:yes_prompt])
+        exit 0 unless SoftLayer::CredentialManager.list_software_credentials(softlayer_client,
+                                                                             :filter     => list_filter,
+                                                                             :yes_prompt => @config[:yes_prompt])
 
       when :"list-details"
-        SoftLayerCredentialManager.list_software_credential_details(softlayer_client, @config[:action_args])
+        SoftLayerManager.list_software_credential_details(softlayer_client, @config[:action_args])
 
       when :set
         set_filter            = @config[:filters]
         set_filter[:username] = @config[:username] unless @config[:username].empty?
 
-        exit 0 unless SoftLayer::SoftLayerCredentialManager.set_software_credentials(softlayer_client,
-                                                                                     @config[:password],
-                                                                                     :add_user_password => @config[:add_user_password],
-                                                                                     :filter            => @config[:filters],
-                                                                                     :yes_prompt        => @config[:yes_prompt])
+        exit 0 unless SoftLayer::CredentialManager.set_software_credentials(softlayer_client,
+                                                                            @config[:password],
+                                                                            :add_user_password => @config[:add_user_password],
+                                                                            :filter            => @config[:filters],
+                                                                            :yes_prompt        => @config[:yes_prompt])
 
       end
     end

--- a/contrib/vagrant-softlayer-credentials
+++ b/contrib/vagrant-softlayer-credentials
@@ -101,6 +101,45 @@ module SoftLayer
         return true
       end
 
+      def self.list_storage_credentials(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+          return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
+        end
+
+        storage_credentials_by_username = {}
+        storage_credentials_data        = get_storage_credentials(softlayer_client, options)
+        storage_credentials_table       = [ [ "id", "username", "password", "storage type" ] ]
+
+        storage_credentials_data.each do |storage_service, storage_credentials|
+          storage_credentials_by_username[storage_credentials[:primary_credential][:username]] = [
+                                                                                                  nil,
+                                                                                                  storage_credentials[:primary_credential][:username],
+                                                                                                  storage_credentials[:primary_credential][:password],
+                                                                                                  storage_credentials[:type]
+                                                                                                 ]
+        end
+
+        storage_credentials_data.each do |storage_service, storage_credentials|
+          storage_credentials[:secondary_credentials].each do |storage_credential|
+            storage_credentials_by_username[storage_credential.username]    = [
+                                                                               storage_credential['id'],
+                                                                               storage_credential.username,
+                                                                               storage_credential.password,
+                                                                               storage_credentials[:type].to_s,
+                                                                              ]
+          end
+        end
+
+        storage_credentials_table.concat(storage_credentials_by_username.values)
+
+        pretty_print_table(storage_credentials_table)
+
+        return true
+      end
+
       def self.set_network_message_delivery_credentials(softlayer_client, password, options = {})
         raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
         raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
@@ -143,6 +182,33 @@ module SoftLayer
 
         if options[:add_user_password]
           add_software_credentials(softlayer_client, password, options)
+        end
+
+        return true
+      end
+
+      def self.set_storage_credentials(softlayer_client, password, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if (! options[:filter] || options[:filter].empty?) && (! options[:yes_prompt])
+          return false unless yes_prompt("No filter options have been specified to narrow credential selection list, it may take a while to process, continue?")
+        end
+
+        if ! options[:yes_prompt]
+          return false unless yes_prompt("You are setting one or more storage credentials, this cannot be undone, continue?")
+        end
+
+        network_storage_data = get_storage(softlayer_client, options)
+        user_filter          = (options[:filter] && options[:filter][:username]) ? options[:filter][:username] : []
+
+        network_storage_data.each do |network_storage|
+          network_storage.password=(password) if user_filter.empty? || user_filter.include?(network_storage.username)
+          network_storage.credentials.each do |credential|
+            if (user_filter.empty? || user_filter.include?(network_storage.username)) && network_storage.username != credential.username
+              network_storage.update_credential_password(credential.username, password)
+            end
+          end
         end
 
         return true
@@ -244,6 +310,93 @@ module SoftLayer
         return software_passwords
       end
 
+      def self.get_storage(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        if options[:filter] && options[:filter][:network_storage_type] && ! options[:filter][:network_storage_type].empty?
+          storage_types                  = options[:filter][:network_storage_type]
+        else
+          storage_types                  = [ :evault, :hub, :iscsi, :lockbox, :nas, :network_storage ]
+        end
+
+        list_hardware_storage_credentials       = (options[:filter] && options[:filter][:virtual_servers_only]) ? false : true
+        list_virtual_server_storage_credentials = (options[:filter] && options[:filter][:hardware_only])        ? false : true
+
+        object_filters                          = storage_filters(options)
+
+        network_storage_data = {}
+
+        if list_hardware_storage_credentials
+          storage_types.each do |storage_type|
+            network_storage = SoftLayer::NetworkStorage.find_network_storage(:client                        => softlayer_client,
+                                                                             :network_storage_object_filter => object_filters[:hardware][storage_type],
+                                                                             :network_storage_type          => storage_type)
+
+            network_storage.each { |net_stor| network_storage_data[net_stor['id']] = net_stor }
+          end
+        end
+
+        if list_virtual_server_storage_credentials
+          storage_types.each do |storage_type|
+            network_storage = SoftLayer::NetworkStorage.find_network_storage(:client                        => softlayer_client,
+                                                                             :network_storage_object_filter => object_filters[:virtual_server][storage_type],
+                                                                             :network_storage_type          => storage_type)
+
+            network_storage.each { |net_stor| network_storage_data[net_stor['id']] = net_stor }
+          end
+        end
+
+        network_storage_data = network_storage_data.values
+        
+        if options[:filter] && options[:filter][:username] && ! options[:filter][:username].empty?
+            network_storage_data.delete_if do |network_storage|
+              ! (options[:filter][:username] - [ network_storage.username, network_storage.credentials.map{|cred| cred.username} ].flatten).empty?
+            end
+        end
+
+        return network_storage_data
+      end
+
+      def self.get_storage_credentials(softlayer_client, options = {})
+        raise "#{__method__} requires a SoftLayer client but none was given"   if !softlayer_client
+        raise "Expected an instance of SoftLayer::Client for softlayer_client" unless softlayer_client.kind_of?(SoftLayer::Client)
+
+        network_storage_data = get_storage(softlayer_client, options)
+
+        storage_credentials = {}
+
+        user_filter = (options[:filter] && options[:filter][:username]) ? options[:filter][:username] : []
+
+        network_storage_data.each do |network_storage|
+          storage_credentials[network_storage.service_resource.private_ip] ||= {
+            :primary_credential => {
+              :password => nil,
+              :username => nil
+            },
+            :secondary_credentials => [],
+            :type => nil
+          }
+
+          storage_credentials[network_storage.service_resource.private_ip][:type] = network_storage.type
+
+          if user_filter.empty? || user_filter.include?(network_storage.username)
+            storage_credentials[network_storage.service_resource.private_ip][:primary_credential] = {
+              :password => network_storage.password,
+              :username => network_storage.username
+            }
+          end
+          
+          network_storage.credentials.each do |credential|
+            if user_filter.empty? || user_filter.include?(credential.username)
+              storage_credentials[network_storage.service_resource.private_ip][:secondary_credentials].push(credential)
+            end
+          end
+        end
+
+        return storage_credentials
+      end
+
       def self.object_filter_criteria_contains(object_filter, filter_path, contains_data)
         object_filter.set_criteria_for_key_path(filter_path,
                                                 {
@@ -255,7 +408,9 @@ module SoftLayer
                                                 })
       end
 
-      def self.pretty_print_table(table)
+      def self.pretty_print_table(table_data)
+        table = table_data.dup
+        table.map { |table_row| table_row.map! {|table_col| table_col.to_s } }
         max_col_widths = table.transpose.map { |col| col.group_by(&:size).max.first + 2 }
         print ':' + max_col_widths.map { |col_width| '.' * col_width}.join(':' ) + ":\n:"
         table[0].each_index {|col| print table[0][col].center(max_col_widths[col]) + ':' }
@@ -302,14 +457,7 @@ module SoftLayer
         if options[:filter]
           option_to_filter_path.each do |option, filter_path|
             if options[:filter][option] && ! options[:filter][option].empty?
-              net_msg_deliv_object_filter.set_criteria_for_key_path(filter_path,
-                                                                    {
-                                                                      'operation' => 'in',
-                                                                      'options' => [{
-                                                                                      'name' => 'data',
-                                                                                      'value' => options[:filter][option].collect{ |tag_value| tag_value.to_s }
-                                                                                    }]
-                                                                    })
+              object_filter_criteria_contains(net_msg_deliv_object_filter, filter_path, options[:filter][option])
             end
           end
         end
@@ -414,6 +562,76 @@ module SoftLayer
         }
       end
 
+      def self.storage_filters(options = {})
+        filter_label = {
+          :evault          => "evaultNetworkStorage",
+          :hardware        => "hardware",
+          :hub             => "hubNetworkStorage",
+          :iscsi           => "iscsiNetworkStorage",
+          :lockbox         => "lockboxNetworkStorage",
+          :nas             => "nasNetworkStorage",
+          :network_storage => "networkStorage",
+          :virtual_server  => "virtualGuest"
+        }
+
+        list_hardware_storage_credentials       = (options[:filter] && options[:filter][:virtual_servers_only]) ? false : true
+        list_virtual_server_storage_credentials = (options[:filter] && options[:filter][:hardware_only])        ? false : true
+
+        option_to_filter_path = {
+          :datacenter => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.datacenter.name' ].join                  },
+          :domain     => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.domain' ].join                           },
+          :hostname   => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.hostname' ].join                         },
+          :service    => lambda { |storage_type|              return [ filter_label[storage_type],                                 '.serviceResource.backendIpAddress' ].join },
+          :tags       => lambda { |storage_type, server_type| return [ filter_label[storage_type], '.', filter_label[server_type], '.tagReferences.tag.name' ].join           }
+        }
+
+        storage_object_filter = {
+          :hardware       => {},
+          :virtual_server => {}
+        }
+
+        if options[:filter] && options[:filter][:network_storage_type] && ! options[:filter][:network_storage_type].empty?
+          storage_types                  = options[:filter][:network_storage_type]
+        else
+          storage_types                  = filter_label.keys.select{|label| filter_label[label].end_with?("Storage") }
+        end
+
+        if list_hardware_storage_credentials
+          storage_types.each {|storage_type| storage_object_filter[:hardware][storage_type]       = SoftLayer::ObjectFilter.new() }
+        end
+
+        if list_virtual_server_storage_credentials
+          storage_types.each {|storage_type| storage_object_filter[:virtual_server][storage_type] = SoftLayer::ObjectFilter.new() }
+        end
+
+        if options[:filter]
+          [ :datacenter, :domain, :hostname, :tags ].each do |option|
+            filter_path = option_to_filter_path[option]
+            if options[:filter][option] && ! options[:filter][option].empty?
+              if list_hardware_storage_credentials
+                storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:hardware][storage_type], filter_path.call(storage_type, :hardware), options[:filter][option]) }
+              end
+
+              if list_virtual_server_storage_credentials
+                storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:virtual_server][storage_type], filter_path.call(storage_type, :virtual_server), options[:filter][option]) }
+              end
+            end
+          end
+
+          if options[:filter][:service] && ! options[:filter][:service].empty?
+            if list_hardware_storage_credentials
+              storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:hardware][storage_type], options_to_filter_path[:service].call(storage_type), options[:filter][:service]) }
+            end
+
+            if list_virtual_server_storage_credentials
+              storage_types.each {|storage_type| object_filter_criteria_contains(storage_object_filter[:virtual_server][storage_type], options_to_filter_path[:service].call(storage_type), options[:filter][:service]) }
+            end
+          end
+        end
+        
+        return storage_object_filter
+      end
+
       def self.software_password_mask(mask_type)
         case mask_type
         when :list
@@ -444,6 +662,20 @@ module SoftLayer
                                                              ]
           }.to_sl_object_mask
         end
+      end
+
+      def self.storage_credential_mask(mask_type)
+        {
+          "mask(SoftLayer_Network_Storage_Credential)" => [
+                                                           'createDate',
+                                                           'id',
+                                                           'modifyDate',
+                                                           'password',
+                                                           'type.description',
+                                                           'type.name',
+                                                           'username'
+                                                          ]
+        }.to_sl_object_mask
       end
 
       def self.yes_prompt(prompt_message)
@@ -482,6 +714,7 @@ class VagrantSoftLayerCredentials
                  [ '--sl_endpoint_url', '-e', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--sl_timeout',      '-t', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--sl_username',     '-u', GetoptLong::REQUIRED_ARGUMENT ],
+                 [ '--storage_type',    '-s', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--tag',             '-T', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--username',        '-U', GetoptLong::REQUIRED_ARGUMENT ],
                  [ '--vendor',          '-v', GetoptLong::REQUIRED_ARGUMENT ],
@@ -509,7 +742,8 @@ class VagrantSoftLayerCredentials
     }
     @help = {
       :network_message_delivery => {},
-      :software                 => {}
+      :software                 => {},
+      :storage                  => {}
     }
 
     @help[:std_opts] = <<-HELP_STD_OPTS
@@ -548,6 +782,10 @@ software:
   list          List credential username/password(s) for installed software.
   list-details  List credential details for a specific username/password instance related to installed software.
   set           Set credential password for username(s) related to installed software.
+
+storage:
+  list          List credential username/password(s) for network storage services.
+  set           Set credential password for username(s) related to network storage services.
 
 #{@help[:std_opts]}
 HELP_EOM
@@ -592,6 +830,31 @@ Software Filter Options:
 --virtual_servers:
     Include software credentials from software on virtual servers only (not hardware).
 HELP_SW_FILTERS
+
+    @help[:storage_filters]                 = <<-HELP_STOR_FILTERS
+Storage Filter Options:
+
+--datacenter|-d <DATACENTER>,...:
+    Include network storage credentials from storage whose associated servers match this list of datacenters.
+
+--domain|-D <DOMAIN>,...:
+    Include network storage credentials from storage whose associated servers match this list of domains.
+
+--hardware:
+    Include network storage credentials from storage assoicated with hardware only (not virtual servers).
+
+--hostname|-H <HOSTNAME>,...:
+    Include network storage credentials from storage whose associated servers match this list of hostnames.
+
+--storage_type|-s <STORAGE_TYPE>,...:
+    Include network storage credentials from storage whose storage type match this list of storage types.
+
+--tag|-T <TAG>,...:
+    Include network storage credentials from storage whose associated servers match this list of tags.
+
+--virtual_servers:
+    Include network storage credentials from storage associated with virtual servers only (not hardware).
+HELP_STOR_FILTERS
 
     @help[:network_message_delivery][:list] = <<-HELP_NMD_LIST
 Usage: #{File.basename($0)} network_message_delivery list [options]
@@ -696,6 +959,44 @@ Set Credential Options:
 #{@help[:software_filters]}
 #{@help[:std_opts]}
 HELP_SW_SET_PW
+
+    @help[:storage][:list]    = <<-HELP_STOR_LIST
+Usage: #{File.basename($0)} storage list [options]
+
+List Credential Options:
+
+--username|-u <USERNAME>,...:
+    List the network storage credential(s) for these username(s) only.
+
+--yes|-y:
+    Automatic yes to prompt(s).
+
+#{@help[:storage_filters]}
+#{@help[:std_opts]}
+HELP_STOR_LIST
+
+    @help[:storage][:set]     = <<-HELP_STOR_SET
+Usage: #{File.basename($0)} storage set [options] [<password>]
+
+List Credential Options:
+
+--password|-p:
+    Prompt for password from STDIN instead of expecting password as an argument.
+    If not specified, it is expected that password is provided as an argument to
+    the action. If both the argument and this option are provided, the argument
+    takes precedence and the password will not be read.
+
+--username|-u <USERNAME>,...:
+    Set the software credential password for these username(s) only. If not specified, the password
+    will be set for all software credentials that match other filtering criteria regardless
+    of username.
+
+--yes|-y:
+    Automatic yes to prompt(s).
+
+#{@help[:storage_filters]}
+#{@help[:std_opts]}
+HELP_STOR_SET
   end
 
   def run()
@@ -758,13 +1059,35 @@ HELP_SW_SET_PW
           set_filter            = @config[:filters]
           set_filter[:username] = @config[:username] unless @config[:username].empty?
 
-          exit 0 unless SoftLayer::Managers:Credentials.set_software_credentials(softlayer_client,
+          exit 0 unless SoftLayer::Managers::Credentials.set_software_credentials(softlayer_client,
+                                                                                  @config[:password],
+                                                                                  :add_user_password => @config[:add_user_password],
+                                                                                  :filter            => @config[:filters],
+                                                                                  :yes_prompt        => @config[:yes_prompt])
+            
+        end
+
+      when :storage
+        case @config[:action]
+        when :list
+          list_filter            = @config[:filters]
+          list_filter[:username] = @config[:username] unless @config[:username].empty?
+
+          exit 0 unless SoftLayer::Managers::Credentials.list_storage_credentials(softlayer_client,
+                                                                                  :filter     => list_filter,
+                                                                                  :yes_prompt => @config[:yes_prompt])
+
+        when :set
+          set_filter            = @config[:filters]
+          set_filter[:username] = @config[:username] unless @config[:username].empty?
+
+          exit 0 unless SoftLayer::Managers::Credentials.set_storage_credentials(softlayer_client,
                                                                                  @config[:password],
-                                                                                 :add_user_password => @config[:add_user_password],
                                                                                  :filter            => @config[:filters],
                                                                                  :yes_prompt        => @config[:yes_prompt])
 
         end
+
       end
     rescue Exception => e
       $stderr.puts "ERROR: Failed to perform action #{@config[:action]} on credential category #{@config[:category]}: #{e.message}"
@@ -816,6 +1139,7 @@ HELP_SW_SET_PW
         elsif @config[:password_flag]
           @config[:password] = password_prompt
         end
+
       else
         if ARGV.length >= 3
           $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} does not accept any arguments"
@@ -861,12 +1185,52 @@ HELP_SW_SET_PW
         elsif @config[:password_flag]
           @config[:password] = password_prompt
         end
+
       else
         if ARGV.length >= 3
           $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} does not accept any arguments"
           exit 2
         end
 
+      end
+
+    when "storage"
+      @config[:category] = :storage
+
+      if ARGV[1] == nil
+        $stderr.puts "ERROR: No action provided for credential category #{ARGV[0]}"
+        exit 2
+      end
+
+      case ARGV[1]
+      when "list", "set"
+        @config[:action] = ARGV[1].to_sym
+
+      else
+        $stderr.puts "ERROR: Invalid action for credential category #{ARGV[0]}: #{ARGV[1]}"
+        exit 2
+
+      end
+
+      case ARGV[1]
+      when "set"
+        if ARGV.length != 3 && ! @config[:password_flag]
+          $stderr.puts "ERROR: #{ARGV[0]} action set requires a password be supplied either as an argument or read from STDIN using --password or -p option"
+          exit 2
+        end
+        
+        if ARGV.length == 3
+          @config[:password] = ARGV[2].to_s
+        elsif @config[:password_flag]
+          @config[:password] = password_prompt
+        end
+        
+      else
+        if ARGV.length >= 3
+          $stderr.puts "ERROR: #{ARGV[0]} action #{ARGV[1]} does not accept any arguments"
+          exit 2
+        end
+        
       end
 
     else
@@ -888,8 +1252,9 @@ HELP_SW_SET_PW
         when '--add'
           @config[:add_user_password] = true
 
-        when '--datacenter', '--description', '--domain', '--hardware_type', '--hostname', '--manufacturer', '--name', '--tag', '--vendor'
-          @config[:filters][opt.slice(2, opt.length - 2).to_sym] = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}
+        when '--datacenter', '--description', '--domain', '--hardware_type', '--hostname', '--manufacturer', '--name', '--storage_type', '--tag', '--vendor'
+          @config[:filters][opt.slice(2, opt.length - 2).to_sym] = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}                           unless opt.to_s == '--storage_type'
+          @config[:filters][:network_storage_type]               = optval.to_s.split(',').delete_if{|token| token.empty? || token.match("\s+")}.map{|token| token.to_sym} if     opt.to_s == '--storage_type'
 
         when '--hardware'
           @config[:filters][:hardware_only] = true


### PR DESCRIPTION
This merges the first release of the SoftLayer credentials manager tool to allow managing/changing all credentials (passwordss) in SoftLayer except for webcc passwords. Unlike the Python CLI tool, this one is aimed at bulk updating to allow updating Software passwords of servers in the portal all at once if they use the same password for example.
